### PR TITLE
Add support for multiple instruments and sensors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore PyCharm env
 .idea
+__pycache__

--- a/xml/README.md
+++ b/xml/README.md
@@ -1,0 +1,9 @@
+## Setup
+ - Setup a new Python 3 environment
+ - Install required packages - `pip install -r requirements.txt`
+
+## Convert record.yaml to XML
+  - `python iso_template.py`
+
+## Run tests
+  - `python tests.py`

--- a/xml/cioos_template.xml
+++ b/xml/cioos_template.xml
@@ -42,13 +42,13 @@
 
     <mcc:MD_Identifier>
       {% if 'naming_authority' in record %}
-      <mcc:authority>
-        <cit:CI_Citation>
-          <cit:title xsi:type="lan:PT_FreeText_PropertyType">
-            {{ multi_lang('naming_authority') }}
-          </cit:title>
-        </cit:CI_Citation>
-      </mcc:authority>
+        <mcc:authority>
+          <cit:CI_Citation>
+            <cit:title xsi:type="lan:PT_FreeText_PropertyType">
+              {{ multi_lang('naming_authority') }}
+            </cit:title>
+          </cit:CI_Citation>
+        </mcc:authority>
       {% endif %}
 
       <!-- code: mandatory -->
@@ -262,9 +262,7 @@
               </cit:role>
               <cit:party>
                 <cit:CI_Organisation>
-                      <cit:name xsi:type="lan:PT_FreeText_PropertyType">
                         {{ multi_lang('acknowledgement') }}
-                      </cit:name>
                 </cit:CI_Organisation>
               </cit:party>
             </cit:CI_Responsibility>
@@ -469,84 +467,84 @@
             {{ multi_lang('platform_description') }}
           </mac:description>
 
-          {% for num,instrument in instruments.items() %}
-          <mac:instrument>
-            <mac:MI_Instrument>
-              <!-- identifier: mandatory -->
-              <mac:identifier>
-                <mcc:MD_Identifier>
-                  <!-- code: mandatory -->
-                  <mcc:code xsi:type="lan:PT_FreeText_PropertyType">
-                    <!-- CIOOS core mandatory element -->
-                    <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/identifier/MD_Identifier/code/CharacterString -->
-                    <gco:CharacterString>{{ instrument.id }}</gco:CharacterString>
-                  </mcc:code>
-                  <!-- version: mandatory -->
-                  <mcc:version xsi:type="lan:PT_FreeText_PropertyType">
-                    <!-- CIOOS core mandatory element -->
-                    <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/identifier/MD_Identifier/version/CharacterString -->
-                    <gco:CharacterString>{{ instrument.version }}</gco:CharacterString>
-                  </mcc:version>
-                  <!-- description: mandatory -->
-                  <mcc:description xsi:type="lan:PT_FreeText_PropertyType">
-                    <!-- CIOOS core mandatory element -->
-                    <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/identifier/MD_Identifier/description/CharacterString -->
-                    <gco:CharacterString>{{ instrument.description }}</gco:CharacterString>
-                  </mcc:description>
-                </mcc:MD_Identifier>
-              </mac:identifier>
-              <!-- type: mandatory -->
-              <mac:type xsi:type="lan:PT_FreeText_PropertyType">
-                <!-- CIOOS core mandatory element -->
-                <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/type/CharacterString -->
-                <gco:CharacterString>{{ instrument.type }}</gco:CharacterString>
-              </mac:type>
-              <!-- description: mandatory -->
-              <mac:description xsi:type="lan:PT_FreeText_PropertyType">
-                <!-- CIOOS core mandatory element -->
-                <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/description/CharacterString -->
-                <gco:CharacterString>{{ instrument.description_other }}</gco:CharacterString>
-              </mac:description>
-              <!-- mountedOn: mandatory? -->
-              <mac:mountedOn/>
-              {% for num,sensor in instrument.sensor.items() %}
-              <!-- sensor: mandatory -->
-              <mac:sensor>
-                <mac:MI_Sensor>
+          {% for num, instrument in instruments.items() %}
+            <mac:instrument>
+              <mac:MI_Instrument>
+                <!-- identifier: mandatory -->
+                <mac:identifier>
+                  <mcc:MD_Identifier>
+                    <!-- code: mandatory -->
+                    <mcc:code xsi:type="lan:PT_FreeText_PropertyType">
+                      <!-- CIOOS core mandatory element -->
+                      <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/identifier/MD_Identifier/code/CharacterString -->
+                      <gco:CharacterString>{{ instrument.id }}</gco:CharacterString>
+                    </mcc:code>
+                    <!-- version: mandatory -->
+                    <mcc:version xsi:type="lan:PT_FreeText_PropertyType">
+                      <!-- CIOOS core mandatory element -->
+                      <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/identifier/MD_Identifier/version/CharacterString -->
+                      <gco:CharacterString>{{ instrument.version }}</gco:CharacterString>
+                    </mcc:version>
+                    <!-- description: mandatory -->
+                    <mcc:description xsi:type="lan:PT_FreeText_PropertyType">
+                      <!-- CIOOS core mandatory element -->
+                      <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/identifier/MD_Identifier/description/CharacterString -->
+                      <gco:CharacterString>{{ instrument.description }}</gco:CharacterString>
+                    </mcc:description>
+                  </mcc:MD_Identifier>
+                </mac:identifier>
+                <!-- type: mandatory -->
+                <mac:type xsi:type="lan:PT_FreeText_PropertyType">
+                  <!-- CIOOS core mandatory element -->
+                  <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/type/CharacterString -->
+                  <gco:CharacterString>{{ instrument.type }}</gco:CharacterString>
+                </mac:type>
+                <!-- description: mandatory -->
+                <mac:description xsi:type="lan:PT_FreeText_PropertyType">
+                  <!-- CIOOS core mandatory element -->
+                  <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/description/CharacterString -->
+                  <gco:CharacterString>{{ instrument.description_other }}</gco:CharacterString>
+                </mac:description>
+                <!-- mountedOn: mandatory? -->
+                <mac:mountedOn/>
+                {% for num, sensor in instrument.sensor.items() %}
+                  <!-- sensor: mandatory -->
+                  <mac:sensor>
+                    <mac:MI_Sensor>
 
-                  <!-- identifier: mandatory -->
-                  <mac:identifier>
-                    <mcc:MD_Identifier>
-                      <!-- code: mandatory -->
-                      <mcc:code xsi:type="lan:PT_FreeText_PropertyType">
-                        <!-- CIOOS core mandatory element -->
-                        <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/sensor/MI_Sensor/identifier/MD_Identifier/code/CharacterString -->
-                        <gco:CharacterString>{{ sensor.id }}</gco:CharacterString>
-                      </mcc:code>
-                      <!-- version: mandatory -->
-                      <mcc:version xsi:type="lan:PT_FreeText_PropertyType">
-                        <!-- CIOOS core mandatory element -->
-                        <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/sensor/MI_Sensor/identifier/MD_Identifier/version/CharacterString -->
-                        <gco:CharacterString>{{ sensor.version }}</gco:CharacterString>
-                      </mcc:version>
-                      <!-- description: mandatory -->
-                      <mcc:description xsi:type="lan:PT_FreeText_PropertyType">
-                        <!-- CIOOS core mandatory element -->
-                        <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/sensor/MI_Sensor/identifier/MD_Identifier/description/CharacterString -->
-                        <gco:CharacterString>{{ sensor.description }}</gco:CharacterString>
-                      </mcc:description>
-                    </mcc:MD_Identifier>
-                  </mac:identifier>
-                  <mac:type/>
-                  <!-- hosted: mandatory -->
-                  <mac:hosted>
-                    <!-- mac:MI_Instrument is an association to parent MI_Instrument really needed in this case? -->
-                  </mac:hosted>
-                </mac:MI_Sensor>
-              </mac:sensor>
-              {% endfor %}
-            </mac:MI_Instrument>
-          </mac:instrument>
+                      <!-- identifier: mandatory -->
+                      <mac:identifier>
+                        <mcc:MD_Identifier>
+                          <!-- code: mandatory -->
+                          <mcc:code xsi:type="lan:PT_FreeText_PropertyType">
+                            <!-- CIOOS core mandatory element -->
+                            <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/sensor/MI_Sensor/identifier/MD_Identifier/code/CharacterString -->
+                            <gco:CharacterString>{{ sensor.id }}</gco:CharacterString>
+                          </mcc:code>
+                          <!-- version: mandatory -->
+                          <mcc:version xsi:type="lan:PT_FreeText_PropertyType">
+                            <!-- CIOOS core mandatory element -->
+                            <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/sensor/MI_Sensor/identifier/MD_Identifier/version/CharacterString -->
+                            <gco:CharacterString>{{ sensor.version }}</gco:CharacterString>
+                          </mcc:version>
+                          <!-- description: mandatory -->
+                          <mcc:description xsi:type="lan:PT_FreeText_PropertyType">
+                            <!-- CIOOS core mandatory element -->
+                            <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/sensor/MI_Sensor/identifier/MD_Identifier/description/CharacterString -->
+                            <gco:CharacterString>{{ sensor.description }}</gco:CharacterString>
+                          </mcc:description>
+                        </mcc:MD_Identifier>
+                      </mac:identifier>
+                      <mac:type/>
+                      <!-- hosted: mandatory -->
+                      <mac:hosted>
+                        <!-- mac:MI_Instrument is an association to parent MI_Instrument really needed in this case? -->
+                      </mac:hosted>
+                    </mac:MI_Sensor>
+                  </mac:sensor>
+                {% endfor %}
+              </mac:MI_Instrument>
+            </mac:instrument>
           {% endfor %}
         </mac:MI_Platform>
       </mac:platform>

--- a/xml/cioos_template.xml
+++ b/xml/cioos_template.xml
@@ -262,7 +262,9 @@
               </cit:role>
               <cit:party>
                 <cit:CI_Organisation>
-                        {{ multi_lang('acknowledgement') }}
+                  <cit:name xsi:type="lan:PT_FreeText_PropertyType">
+                    {{ multi_lang('acknowledgement') }}
+                  </cit:name>
                 </cit:CI_Organisation>
               </cit:party>
             </cit:CI_Responsibility>

--- a/xml/cioos_template.xml
+++ b/xml/cioos_template.xml
@@ -41,6 +41,7 @@
   <mdb:metadataIdentifier>
 
     <mcc:MD_Identifier>
+      {% if 'naming_authority' in record %}
       <mcc:authority>
         <cit:CI_Citation>
           <cit:title xsi:type="lan:PT_FreeText_PropertyType">
@@ -48,6 +49,7 @@
           </cit:title>
         </cit:CI_Citation>
       </mcc:authority>
+      {% endif %}
 
       <!-- code: mandatory -->
       <mcc:code xsi:type="lan:PT_FreeText_PropertyType">
@@ -467,6 +469,7 @@
             {{ multi_lang('platform_description') }}
           </mac:description>
 
+          {% for num,instrument in instruments.items() %}
           <mac:instrument>
             <mac:MI_Instrument>
               <!-- identifier: mandatory -->
@@ -476,19 +479,19 @@
                   <mcc:code xsi:type="lan:PT_FreeText_PropertyType">
                     <!-- CIOOS core mandatory element -->
                     <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/identifier/MD_Identifier/code/CharacterString -->
-                    {{ multi_lang('instrument_id') }}
+                    <gco:CharacterString>{{ instrument.id }}</gco:CharacterString>
                   </mcc:code>
                   <!-- version: mandatory -->
                   <mcc:version xsi:type="lan:PT_FreeText_PropertyType">
                     <!-- CIOOS core mandatory element -->
                     <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/identifier/MD_Identifier/version/CharacterString -->
-                    {{ multi_lang('instrument_version') }}
+                    <gco:CharacterString>{{ instrument.version }}</gco:CharacterString>
                   </mcc:version>
                   <!-- description: mandatory -->
                   <mcc:description xsi:type="lan:PT_FreeText_PropertyType">
                     <!-- CIOOS core mandatory element -->
                     <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/identifier/MD_Identifier/description/CharacterString -->
-                    {{ multi_lang('instrument_description') }}
+                    <gco:CharacterString>{{ instrument.description }}</gco:CharacterString>
                   </mcc:description>
                 </mcc:MD_Identifier>
               </mac:identifier>
@@ -496,16 +499,17 @@
               <mac:type xsi:type="lan:PT_FreeText_PropertyType">
                 <!-- CIOOS core mandatory element -->
                 <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/type/CharacterString -->
-                {{ multi_lang('instrument_type') }}
+                <gco:CharacterString>{{ instrument.type }}</gco:CharacterString>
               </mac:type>
               <!-- description: mandatory -->
               <mac:description xsi:type="lan:PT_FreeText_PropertyType">
                 <!-- CIOOS core mandatory element -->
                 <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/description/CharacterString -->
-                {{ multi_lang('instrument_description_other') }}
+                <gco:CharacterString>{{ instrument.description_other }}</gco:CharacterString>
               </mac:description>
               <!-- mountedOn: mandatory? -->
               <mac:mountedOn/>
+              {% for num,sensor in instrument.sensor.items() %}
               <!-- sensor: mandatory -->
               <mac:sensor>
                 <mac:MI_Sensor>
@@ -517,19 +521,19 @@
                       <mcc:code xsi:type="lan:PT_FreeText_PropertyType">
                         <!-- CIOOS core mandatory element -->
                         <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/sensor/MI_Sensor/identifier/MD_Identifier/code/CharacterString -->
-                        {{ multi_lang('sensor_id') }}
+                        <gco:CharacterString>{{ sensor.id }}</gco:CharacterString>
                       </mcc:code>
                       <!-- version: mandatory -->
                       <mcc:version xsi:type="lan:PT_FreeText_PropertyType">
                         <!-- CIOOS core mandatory element -->
                         <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/sensor/MI_Sensor/identifier/MD_Identifier/version/CharacterString -->
-                        {{ multi_lang('sensor_version') }}
+                        <gco:CharacterString>{{ sensor.version }}</gco:CharacterString>
                       </mcc:version>
                       <!-- description: mandatory -->
                       <mcc:description xsi:type="lan:PT_FreeText_PropertyType">
                         <!-- CIOOS core mandatory element -->
                         <!-- MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/sensor/MI_Sensor/identifier/MD_Identifier/description/CharacterString -->
-                        {{ multi_lang('sensor_description') }}
+                        <gco:CharacterString>{{ sensor.description }}</gco:CharacterString>
                       </mcc:description>
                     </mcc:MD_Identifier>
                   </mac:identifier>
@@ -540,8 +544,10 @@
                   </mac:hosted>
                 </mac:MI_Sensor>
               </mac:sensor>
+              {% endfor %}
             </mac:MI_Instrument>
           </mac:instrument>
+          {% endfor %}
         </mac:MI_Platform>
       </mac:platform>
     </mac:MI_AcquisitionInformation>

--- a/xml/iso_template.py
+++ b/xml/iso_template.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-# This is the most basic code needed to load the template and write XML
-
 # From this directory, run: python iso_template.py
 
 
@@ -9,13 +7,88 @@ from jinja2 import Environment, FileSystemLoader
 import yaml
 import re
 from lxml import etree
+import os
+
+TEMPLATE_FILE = './cioos_template.xml'
 
 
-# eg if we have: {title_fra:"le title"}
-# get_alternate_text('title') will return [("fra", "le title")]
-# returns an array because it supports multilingual, not just bilingual
+def get_instruments_from_record(record):
+    ''' converts flat instrument variables to a nested dict
+        See test for example
+    '''
+    instruments = {}
+    for key, val in record.items():
+        matches_instrument = re.search('^instrument_(\d)+_?(\w+)?', key)
+        if not matches_instrument:
+            continue
+
+        instrument_num = matches_instrument[1]
+        if instrument_num not in instruments:
+            instruments[instrument_num] = {}
+
+        instrument = instruments[instrument_num]
+
+        instrument_field = matches_instrument[2]
+
+        matches_sensor = re.search('^sensor_(\d)+_?(\w+)?', instrument_field)
+        if matches_sensor:
+            sensor_num = matches_sensor[1]
+            sensor_field = matches_sensor[2]
+            if 'sensor' not in instrument:
+                instrument['sensor'] = {}
+            if sensor_num not in instrument['sensor']:
+                instrument['sensor'][sensor_num] = {}
+
+            instrument['sensor'][sensor_num][sensor_field] = val
+        else:
+            instrument[instrument_field] = val
+
+    return instruments
+
+
+def check_mandatory_fields(record):
+    # could add more logic here
+    mandatory_fields = [
+        'id',
+        'title',
+        'summary',
+        'language',
+        'language_country',
+        'keywords',
+        'date_created',
+        'creator_name',
+        'creator_url',
+        'creator_email',
+        'institution',
+        'project',
+        'acknowledgement',
+        'contributor_name',
+        'contributor_role',
+        # 'scope_code',
+        # 'platform_id',
+        # 'platform_role',
+        # 'platform_id_authority'
+    ]
+    for field in mandatory_fields:
+        if field not in record:
+            raise Exception("Missing required field: '{}'".format(field))
+
+
 def get_alternate_text_wrapper(record):
+    """ Given a dict, return a function that will take a key and return all
+        the keys for alternate languages
+
+        This function is used inside the Jinja template
+
+        eg if we have: {title_fra:"le title"}
+        get_alternate_text('title') will return [("fra", "le title")]
+        returns an array because it supports multilingual, not just bilingual
+    """
+    if 'language' not in record:
+        raise Exception("missing variable 'langauge' in record")
+
     default_language = record['language']
+
     if not default_language:
         raise Exception("Variable language is required")
 
@@ -50,47 +123,44 @@ def pretty_xml(ugly_xml):
 
     tree = etree.ElementTree(etree.fromstring(ugly_xml, parser=parser))
     xml_pretty_str = etree.tostring(
-        tree.getroot(),
+        tree,
         pretty_print=True,
-        # not using xml_declaration as it uses single quotes
-        doctype='<?xml version="1.0" encoding="UTF-8"?>',
-        encoding='UTF-8')
+        # not using xml_declaration as it produces single quotes
+        # which the validator doesnt like
+        doctype='<?xml version="1.0" encoding="utf-8"?>',
+        encoding="unicode")
     return xml_pretty_str
 
 
-def iso_template(template_file, yaml_file):
-    '''Takes a Jinja template file and a yaml file in this directory and
+def iso_template(record):
+    '''Takes a Jinja template file and a dictionary and
     outputs XML'''
-    TEMPLATE_FOLDER = "./"
 
-    template_loader = FileSystemLoader(searchpath=TEMPLATE_FOLDER)
+    this_dir = os.path.dirname(os.path.realpath(__file__))
+
+    template_loader = FileSystemLoader(searchpath=this_dir)
     template_env = Environment(loader=template_loader, trim_blocks=True,
                                lstrip_blocks=True)
 
-    template = template_env.get_template(template_file)
+    template = template_env.get_template(TEMPLATE_FILE)
 
-    with open(yaml_file) as stream:
-        yaml_data = yaml.safe_load(stream)
-        data = {"record": yaml_data}
-        get_alternate_text = get_alternate_text_wrapper(yaml_data)
-        template_env.filters['get_alternate_text'] = get_alternate_text
-        template_env.globals.update(get_alternate_text=get_alternate_text)
+    check_mandatory_fields(record)
+    get_alternate_text = get_alternate_text_wrapper(record)
+    template_env.filters['get_alternate_text'] = get_alternate_text
+    template_env.globals.update(get_alternate_text=get_alternate_text)
+    template_env.globals.update(
+        instruments=get_instruments_from_record(record))
 
-        xml = template.render(data)
+    xml = pretty_xml(template.render({"record": record}))
 
     return xml
 
 
-# the record input as yaml file
-yaml_file_path = "record.yaml"
+if(__name__ == '__main__'):
+    with open("record.yaml") as stream:
+        yaml_data = yaml.safe_load(stream)
 
-# the jinja template file
-template_path = "cioos_template.xml"
-
-# The output file
-xml_file_path = "record.xml"
-
-xml = pretty_xml(iso_template(template_path,  yaml_file_path))
-file = open(xml_file_path, "wb")
-file.write(xml)
-print("Wrote " + xml_file_path)
+        xml = iso_template(yaml_data)
+        file = open("record.xml", "w")
+        file.write(xml)
+        print("Wrote " + file.name)

--- a/xml/iso_template.py
+++ b/xml/iso_template.py
@@ -18,7 +18,7 @@ def get_instruments_from_record(record):
     '''
     instruments = {}
     for key, val in record.items():
-        matches_instrument = re.search('^instrument_(\d)+_?(\w+)?', key)
+        matches_instrument = re.search(r'^instrument_(\d)+_?(\w+)?', key)
         if not matches_instrument:
             continue
 
@@ -30,7 +30,7 @@ def get_instruments_from_record(record):
 
         instrument_field = matches_instrument[2]
 
-        matches_sensor = re.search('^sensor_(\d)+_?(\w+)?', instrument_field)
+        matches_sensor = re.search(r'^sensor_(\d)+_?(\w+)?', instrument_field)
         if matches_sensor:
             sensor_num = matches_sensor[1]
             sensor_field = matches_sensor[2]
@@ -85,7 +85,7 @@ def get_alternate_text_wrapper(record):
         returns an array because it supports multilingual, not just bilingual
     """
     if 'language' not in record:
-        raise Exception("missing variable 'langauge' in record")
+        raise Exception("missing variable 'language' in record")
 
     default_language = record['language']
 

--- a/xml/record.yaml
+++ b/xml/record.yaml
@@ -2,7 +2,7 @@
 # if english were the default language, there would be title_fra,summary_fra, etc
 
 language: "fra" # or eng
-title: "title in french"
+title: "title in french ééé"
 title_eng: "title in english"
 summary: "summary in french"
 summary_eng: "summary in english"
@@ -67,16 +67,15 @@ language_country: "CAN"
 publisher_country: "publisher_country"
 progress_code: "completed"
 scope_code: "dataset"
-instrument_id: "instrument_id"
-instrument_version: "instrument_version"
-instrument_description_other: "instrument_description_other"
-instrument_description_other_fr: "instrument_description_other in french"
 
-instrument_type: "instrument_type"
-sensor_id: "sensor_id"
-sensor_version: "sensor_version"
-sensor_description: "sensor_description in french"
-sensor_description_eng: "sensor_description in english"
+instrument_1_id: instrument_1_id
+instrument_1_version: instrument_1_version
+instrument_1_type: instrument_1_type
+instrument_1_description: instrument_1_description
+
+instrument_1_sensor_1_id: instrument_1_sensor_1_id
+instrument_1_sensor_1_version: instrument_1_sensor_1_version
+instrument_1_sensor_1_description: instrument_1_sensor_1_description
 
 platform_name: "platform_name" # from cf
 platform_id: "platform_id" # from cf

--- a/xml/record.yaml
+++ b/xml/record.yaml
@@ -23,8 +23,8 @@ creator_name: "creator_name"
 creator_url: "creator_url"
 creator_email: "nobody@example.com"
 institution: "institution"
-project: "project in french"
-project_eng: "project in english"
+project: "project1 in french,project2 in french"
+project_eng: "project1 in english,project2 in english"
 processing_level: "processing level in french"
 processing_level_eng: "processing level in english"
 acknowledgement: "acknowledgement in french"
@@ -34,8 +34,8 @@ geospatial_lat_min: -89.975
 geospatial_lat_max: 89.975
 geospatial_lon_min: -179.975
 geospatial_lon_max: 179.975
-geospatial_vertical_min: "geospatial_vertical_min"
-geospatial_vertical_max: "geospatial_vertical_max"
+geospatial_vertical_min: 1.23
+geospatial_vertical_max: 5.67
 time_coverage_start: "1985-03-25T12:00:00Z"
 time_coverage_end: "1985-04-25T12:00:00Z"
 # copied these from https://coastwatch.pfeg.noaa.gov/erddap/info/NOAA_DHW/index.html
@@ -53,9 +53,9 @@ publisher_email: "publisher_email"
 date_modified: "2019-10-07T21:27:22Z"
 date_issued: "2010-01-24"
 geospatial_lat_units: "degrees_north"
-geospatial_lat_resolution: "geospatial_lat_resolution"
+geospatial_lat_resolution: "1.23"
 geospatial_lon_units: "geospatial_lon_units"
-geospatial_lon_resolution: "geospatial_lon_resolution"
+geospatial_lon_resolution: "4.56"
 geospatial_vertical_units: "geospatial_vertical_units"
 geospatial_vertical_resolution: "geospatial_vertical_resolution"
 geospatial_vertical_positive: "vertical"

--- a/xml/record.yaml
+++ b/xml/record.yaml
@@ -37,7 +37,7 @@ geospatial_lon_max: 179.975
 geospatial_vertical_min: "geospatial_vertical_min"
 geospatial_vertical_max: "geospatial_vertical_max"
 time_coverage_start: "1985-03-25T12:00:00Z"
-time_coverage_engd: "1985-04-25T12:00:00Z"
+time_coverage_end: "1985-04-25T12:00:00Z"
 # copied these from https://coastwatch.pfeg.noaa.gov/erddap/info/NOAA_DHW/index.html
 time_coverage_duration: "P1D"
 time_coverage_resolution: "P1D"

--- a/xml/requirements.txt
+++ b/xml/requirements.txt
@@ -1,4 +1,3 @@
-certifi==2016.2.28
 Jinja2==2.10.3
 lxml==4.4.1
 MarkupSafe==1.1.1

--- a/xml/requirements.txt
+++ b/xml/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2016.2.28
+Jinja2==2.10.3
+lxml==4.4.1
+MarkupSafe==1.1.1
+PyYAML==5.1.2

--- a/xml/tests.py
+++ b/xml/tests.py
@@ -1,0 +1,60 @@
+import unittest
+import lxml
+from iso_template import (get_alternate_text_wrapper,
+                          pretty_xml,
+                          get_instruments_from_record)
+
+
+class TestISOTemplateFunctions(unittest.TestCase):
+
+    def test_get_alternate_text_wrapper(self):
+
+        # get_alternate_text_wrapper
+        record = {"language": "eng",
+                  "title": "title in english",
+                  "title_fra": "title in french"}
+
+        get_alternate_text = get_alternate_text_wrapper(record)
+
+        out = get_alternate_text('title')
+        self.assertEqual([('fra', 'title in french')], out)
+
+    def test_get_alternate_text_no_language(self):
+        # error: missing language
+        record = {"title": "title in english"}
+        self.assertRaises(Exception, get_alternate_text_wrapper, record)
+
+    def test_get_alternate_text_bad_key(self):
+        # error: there is an alternate language set to the default language
+        record = {"language": "eng",
+                  "title_eng": "title in english"}
+        get_alternate_text = get_alternate_text_wrapper(record)
+        self.assertRaises(Exception, get_alternate_text, 'title')
+
+    def test_pretty_xml(self):
+        self.assertEqual(
+            '<?xml version="1.0" encoding="utf-8"?>\n<xml>sdf</xml>\n',
+            pretty_xml('<xml>sdf</xml>'))
+        # check that bad xml throws an error
+        self.assertRaises(lxml.etree.XMLSyntaxError, pretty_xml,
+                          '<xml>sdf</xml')
+
+    def test_get_instruments_from_record(self):
+        record = {
+            "instrument_2_id": "instrument_2_id",
+            "instrument_2_sensor_1_id": "sensor_id",
+        }
+        self.assertEqual({
+            '2': {
+                'id': 'instrument_2_id',
+                'sensor': {
+                    '1': {
+                        'id': 'sensor_id'
+                    }
+                }
+            }
+        }, get_instruments_from_record(record))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
In this PR,
 - add support for multiple instruments and sensors in the template, made some assumptions about how it should be setup in the XML
 - added tests
 - made script module friendly so it can be imported
 - added requirements.txt
 - added a basic readme