### PR TITLE
add field erddap_dataset_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ See example .yaml files in the 'sample_records' directory for more examples.
     - date_issued
     - date_modified
     - date_modified
+    - erddap_dataset_url
     - geospatial_lat_max
     - geospatial_lat_min
     - geospatial_lon_max

--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -534,6 +534,39 @@
     </mri:MD_DataIdentification>
   </mdb:identificationInfo>
 
+  {% if record['erddap_dataset_url'] %}
+    <mdb:distributionInfo>
+      <mrd:MD_Distribution>
+        <mrd:transferOptions>
+          <mrd:MD_DigitalTransferOptions>
+            <mrd:onLine>
+              <cit:CI_OnlineResource>
+                <cit:linkage>
+                  <gco:CharacterString>{{ record['erddap_dataset_url'] }}</gco:CharacterString>
+                </cit:linkage>
+                <cit:protocol>
+                  <gco:CharacterString>order</gco:CharacterString>
+                </cit:protocol>
+                <cit:name>
+                  <gco:CharacterString>ERDDAP Data Subset Form</gco:CharacterString>
+                </cit:name>
+                <cit:description>
+                  <gco:CharacterString>ERDDAP's version of the OPeNDAP .html web page for this dataset. Specify a subset of the dataset and download the data via OPeNDAP or in many different file types.</gco:CharacterString>
+                </cit:description>
+                <cit:function>
+                  <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode" codeListValue="download"/>
+                </cit:function>
+                <cit:protocolRequest>
+                  <gco:CharacterString>OPeNDAP constraint protocol</gco:CharacterString>
+                </cit:protocolRequest>
+              </cit:CI_OnlineResource>
+            </mrd:onLine>
+          </mrd:MD_DigitalTransferOptions>
+        </mrd:transferOptions>
+      </mrd:MD_Distribution>
+    </mdb:distributionInfo>
+  {% endif %}
+
   {% if record['history'] %}
     <mdb:resourceLineage>
       <mrl:LI_Lineage>

--- a/metadata_xml/tests.py
+++ b/metadata_xml/tests.py
@@ -101,6 +101,11 @@ class TestISOTemplateFunctions(unittest.TestCase):
 
     def test_sanitize_record(self):
         self.assertEqual(sanitize_record({"title": None}), {})
+        self.assertEqual(
+            sanitize_record(
+                {"erddap_dataset_url": "http://example.com?a&b"}),
+            {"erddap_dataset_url": "http://example.com?a&amp;b"}
+        )
 
     def test_list_intersection(self):
         self.assertEqual(list_intersection([1, 2], [2, 3]), [2])

--- a/sample_records/record.yaml
+++ b/sample_records/record.yaml
@@ -19,6 +19,7 @@ comment: "comment in french"
 comment_eng: "comment in english"
 
 date_created: "2010-01-22"
+erddap_dataset_url: "http://example.com/erddap/tabledap/MyDataset.html"
 creator_name: "creator_name"
 creator_url: "creator_url"
 creator_email: "nobody@example.com"


### PR DESCRIPTION
I added a field called `erddap_dataset_url` which lets you reference an ERDDAP URL. For the XML I just copied what ERDDAP generates and changed it to fit our ISO schema. The erddap_xml_creator package populates this field automatically 