### PR TITLE
CircleCI without tracking all the schema files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2
+jobs:
+  build:
+    machine: true
+    steps:
+      - checkout
+
+      # build the application image
+      - run: docker build ./ --tag metadata_xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+# Run tests using docker
+FROM python:3
+WORKDIR /repo
+COPY . .
+RUN sh docker_init.sh

--- a/docker_init.sh
+++ b/docker_init.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This script is run by Docker and CircleCI
+set -e
+pip -q install . 
+cd metadata_xml && python -m unittest tests.py
+cd ..
+wget https://pac-dev1.cioos.org/dev/public/schema.zip -q
+unzip -qq schema.zip
+apt update -qq && apt install --yes -qq libxml2-utils
+for i in sample_records/*.yaml; do echo "$i";python -m metadata_xml -f "$i"; done
+for i in *.xml; do echo "$i";xmllint --noout --schema ./standards.iso.org/iso/19115/-3/mds/2.0/mds.xsd "$i"; done

--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -520,7 +520,7 @@
       {% if record['license'] %}
       <mri:resourceConstraints>
         <mco:MD_LegalConstraints>
-          <mco:useLimitation>
+          <mco:useLimitation xsi:type="lan:PT_FreeText_PropertyType">
             {{ multi_lang('license') }}
           </mco:useLimitation>
         </mco:MD_LegalConstraints>

--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -321,7 +321,7 @@
                     <cit:CI_Contact>
                       <cit:onlineResource>
                         <cit:CI_OnlineResource>
-                          <cit:linkage xsi:type="lan:PT_FreeText_PropertyType">
+                          <cit:linkage>
                             <gco:CharacterString>{{ record['creator_url'] }}</gco:CharacterString>
                           </cit:linkage>
                         </cit:CI_OnlineResource>


### PR DESCRIPTION
This way we can get automatic and local schema validation without committing all the XSD files. It's a bit slower this way but cleaner. Test failing means its working