### PR TITLE
Use same directory for file i/o.

### DIFF
--- a/docker_init.sh
+++ b/docker_init.sh
@@ -8,4 +8,4 @@ wget https://pac-dev1.cioos.org/dev/public/schema.zip -q
 unzip -qq schema.zip
 apt update -qq && apt install --yes -qq libxml2-utils
 for i in sample_records/*.yaml; do echo "$i";python -m metadata_xml -f "$i"; done
-for i in *.xml; do echo "$i";xmllint --noout --schema ./standards.iso.org/iso/19115/-3/mds/2.0/mds.xsd "$i"; done
+for i in sample_records/*.xml; do echo "$i";xmllint --noout --schema ./standards.iso.org/iso/19115/-3/mds/2.0/mds.xsd "$i"; done

--- a/metadata_xml/__main__.py
+++ b/metadata_xml/__main__.py
@@ -36,6 +36,8 @@ if __name__ == '__main__':
         yaml_data = yaml.safe_load(stream)
 
         xml = iso_template(yaml_data, use_validation=True)
-        file = open(basename.split('.')[0] + ".xml", "w")
+        pre, ext = os.path.splitext(filename)
+        yaml_filename = f'{pre}.xml'
+        file = open(yaml_filename, "w")
         file.write(xml)
         print("Wrote " + file.name)


### PR DESCRIPTION
We're using a github repo to store our WAF XML files, with the .yml files alongside the .xml files. As such it's easier for our use case if the output .xml is in the same directory as the input .yml. However if this is not useful for Hakai or others I can modify it.