### PR TITLE
add indeterminatePosition to TemporalExtent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea
 __pycache__
 *.egg-info
+
+venv/

--- a/README.md
+++ b/README.md
@@ -111,3 +111,13 @@ These can be repeated with different instrument/sensor numbers, eg:
 - instrument_1_sensor_1_id
 - instrument_1_sensor_1_description
 - instrument_1_sensor_1_version
+
+## Running tests
+
+```bash
+cd metadata_xml
+python -m unittest tests.py
+```
+
+Or using Docker, from this directory:
+`docker build ./ --tag metadata_xml`

--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -559,6 +559,7 @@
         <gex:EX_Extent>
           <gex:temporalElement>
             <gex:EX_TemporalExtent>
+            {# CIOOS core mandatory element #}
               <gex:extent>
                 <gml:TimePeriod gml:id="time_period">
                   <gml:beginPosition>{{ record['time_coverage_start'] }}</gml:beginPosition>
@@ -566,6 +567,26 @@
                   {% if record['time_coverage_duration']  %}
                   <gml:duration>{{ record['time_coverage_duration'] }}</gml:duration>
                   {% endif %}
+                </gml:TimePeriod>
+              </gex:extent>
+            </gex:EX_TemporalExtent>
+          </gex:temporalElement>
+        </gex:EX_Extent>
+      </mri:extent>
+      {% elif not record['progress_code'] or record['progress_code'] == 'onGoing' %}
+      {# if start and end not set then can use indeterminatePosition for onGoing datasets #}
+      <mri:extent>
+        <gex:EX_Extent>
+          <gex:temporalElement>
+            <gex:EX_TemporalExtent>
+              <gex:extent>
+                <gml:TimePeriod gml:id="time_period">
+                  {% if record['time_coverage_start'] %}
+                  <gml:beginPosition>{{ record['time_coverage_start'] }}</gml:beginPosition>
+                  {% else %}
+                  <gml:beginPosition indeterminatePosition="unknown"/>
+                  {% endif %}
+                  <gml:endPosition indeterminatePosition="now"/>
                 </gml:TimePeriod>
               </gex:extent>
             </gex:EX_TemporalExtent>


### PR DESCRIPTION
add indeterminatePosition to TemporalExtent begin and end tags to handle datasets with onGoing collection status. update test instructions in readme.