### PR TITLE
platform / instrument / sensor review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea
 __pycache__
 *.egg-info
+
+venv/

--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -813,7 +813,7 @@
     </mdb:metadataMaintenance>
 
   {% if record['platform_name'] %}
-  {# acquisitionInformation: Recomended #}
+  {# acquisitionInformation: Recommended #}
   <mdb:acquisitionInformation>
     <mac:MI_AcquisitionInformation>
       {# scope: CIOOS core mandatory #}
@@ -826,7 +826,7 @@
         </mcc:MD_Scope>
       </mac:scope>
 
-      {# platform: Recomended #}
+      {# platform: Recommended #}
       <mac:platform>
         <mac:MI_Platform>
 
@@ -884,14 +884,14 @@
           </mac:description>
 
           {% for num, instrument in instruments.items() %}
-            {# instrument: Recomended, if platform not used then this should be under mac:MI_AcquisitionInformation #}
+            {# instrument: Recommended, if platform not used then this should be under mac:MI_AcquisitionInformation #}
             <mac:instrument>
-              {# MI_Instrument: Recomended #}
+              {# MI_Instrument: Recommended #}
               <mac:MI_Instrument>
                 {# identifier: mandatory #}
                 <mac:identifier>
                   <mcc:MD_Identifier>
-                    {# authority: Recomended #}
+                    {# authority: Recommended #}
                     {% if instrument.manufacturer %}
                     <mcc:authority>
                       <cit:CI_Citation>

--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -969,7 +969,7 @@
                       <mac:type>
                         {# type: mandatory #}
                         <gco:CharacterString>{{ sensor.type }}</gco:CharacterString>
-                      <mac:type/>
+                      </mac:type>
                       {# hosted: optional #}
                       <mac:hosted>
                         {# mac:MI_Instrument is an association to parent MI_Instrument really needed in this case? #}

--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -883,7 +883,7 @@
             {{ multi_lang('platform_description') }}
           </mac:description>
 
-          {% for num, instrument in instruments.items() %}
+          {% for instrument_num, instrument in instruments.items() %}
             {# instrument: Recommended, if platform not used then this should be under mac:MI_AcquisitionInformation #}
             <mac:instrument>
               {# MI_Instrument: Recommended #}
@@ -917,10 +917,10 @@
                     {% endif %}
                     {% if instrument.description %}
                     {# description: mandatory #}
-                    <mcc:description>
+                    <mcc:description xsi:type="lan:PT_FreeText_PropertyType">
                       {# CIOOS core mandatory element #}
                       {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/identifier/MD_Identifier/description/CharacterString #}
-                      <gco:CharacterString>{{ instrument.description }}</gco:CharacterString>
+                      {{ multi_lang('instrument_' + instrument_num + '_description') }}
                     </mcc:description>
                     {% endif %}
                   </mcc:MD_Identifier>
@@ -934,7 +934,7 @@
 
                 {# mountedOn: mandatory? #}
                 <mac:mountedOn/>
-                {% for num, sensor in instrument.sensor.items() %}
+                {% for sensor_num, sensor in instrument.sensor.items() %}
                   {# sensor: mandatory #}
                   <mac:sensor>
                     <mac:MI_Sensor>
@@ -958,10 +958,10 @@
                           {% endif %}
                           {% if sensor.description %}
                           {# description: mandatory #}
-                          <mcc:description>
+                          <mcc:description xsi:type="lan:PT_FreeText_PropertyType">
                             {# CIOOS core mandatory element #}
                             {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/sensor/MI_Sensor/identifier/MD_Identifier/description/CharacterString #}
-                            <gco:CharacterString>{{ sensor.description }}</gco:CharacterString>
+                            {{ multi_lang('instrument_' + instrument_num + '_sensor_' + sensor_num + '_description') }}
                           </mcc:description>
                           {% endif %}
                         </mcc:MD_Identifier>

--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -932,14 +932,6 @@
                   <gco:CharacterString>{{ instrument.type }}</gco:CharacterString>
                 </mac:type>
 
-                {# description: mandatory #}
-                {% if instrument.description_other %}
-                <mac:description>
-                  {# CIOOS core mandatory element #}
-                  {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/description/CharacterString #}
-                  <gco:CharacterString>{{ instrument.description_other }}</gco:CharacterString>
-                </mac:description>
-                {% endif %}
                 {# mountedOn: mandatory? #}
                 <mac:mountedOn/>
                 {% for num, sensor in instrument.sensor.items() %}

--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -399,8 +399,8 @@
                     <cit:CI_Contact>
                       <cit:address>
                         <cit:CI_Address>
-                          <cit:electronicMailAddress xsi:type="lan:PT_FreeText_PropertyType">
-                            {{ multi_lang('creator_email') }}
+                          <cit:electronicMailAddress>
+                            <gco:CharacterString>{{ record['creator_email'] }}</gco:CharacterString>
                           </cit:electronicMailAddress>
                         </cit:CI_Address>
                       </cit:address>

--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -144,7 +144,7 @@
                   {# electronicMailAddress: mandatory #}
 
                   {% if record['publisher_email'] %}
-                  <cit:electronicMailAddress xsi:type="lan:PT_FreeText_PropertyType">
+                  <cit:electronicMailAddress>
                     {# CIOOS core mandatory element #}
                     {# MI_Metadata/contact/CI_Responsibility/party/contactInfo/CI_Contact/address/CI_Address/electronicMailAddress/CharacterString #}
                     <gco:CharacterString>{{ record['publisher_email'] }}</gco:CharacterString>
@@ -157,7 +157,7 @@
 
               <cit:onlineResource>
                 <cit:CI_OnlineResource>
-                  <cit:linkage xsi:type="lan:PT_FreeText_PropertyType">
+                  <cit:linkage>
                     <gco:CharacterString>{{ record['publisher_url'] }}</gco:CharacterString>
                   </cit:linkage>
                 </cit:CI_OnlineResource>
@@ -379,7 +379,7 @@
               <cit:party>
                 <cit:CI_Individual>
                   {# name: mandatory #}
-                  <cit:name xsi:type="lan:PT_FreeText_PropertyType">
+                  <cit:name>
                     {# CIOOS core mandatory element #}
                     {# MI_Metadata/identificationInfo/MD_DataIdentification/citation/CI_Citation/party/CI_Party/name/CharacterString #}
                     <gco:CharacterString>{{ record['creator_name'] }}</gco:CharacterString>
@@ -837,7 +837,7 @@
               <mcc:authority>
                 <cit:CI_Citation>
                   {# validation says cit:CI_Citation requires title #}
-                  <cit:title xsi:type="lan:PT_FreeText_PropertyType">
+                  <cit:title>
                     <gco:CharacterString>{{ record['platform_name'] }}</gco:CharacterString>
                   </cit:title>
 
@@ -902,14 +902,14 @@
                     </mcc:authority>
                     {% endif %}
                     {# code: mandatory #}
-                    <mcc:code xsi:type="lan:PT_FreeText_PropertyType">
+                    <mcc:code>
                       {# CIOOS core mandatory element #}
                       {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/identifier/MD_Identifier/code/CharacterString #}
                       <gco:CharacterString>{{ instrument.id }}</gco:CharacterString>
                     </mcc:code>
                     {% if instrument.version %}
                     {# version: mandatory #}
-                    <mcc:version xsi:type="lan:PT_FreeText_PropertyType">
+                    <mcc:version>
                       {# CIOOS core mandatory element #}
                       {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/identifier/MD_Identifier/version/CharacterString #}
                       <gco:CharacterString>{{ instrument.version }}</gco:CharacterString>
@@ -917,7 +917,7 @@
                     {% endif %}
                     {% if instrument.description %}
                     {# description: mandatory #}
-                    <mcc:description xsi:type="lan:PT_FreeText_PropertyType">
+                    <mcc:description>
                       {# CIOOS core mandatory element #}
                       {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/identifier/MD_Identifier/description/CharacterString #}
                       <gco:CharacterString>{{ instrument.description }}</gco:CharacterString>
@@ -926,7 +926,7 @@
                   </mcc:MD_Identifier>
                 </mac:identifier>
                 {# type: mandatory #}
-                <mac:type xsi:type="lan:PT_FreeText_PropertyType">
+                <mac:type>
                   {# CIOOS core mandatory element #}
                   {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/type/CharacterString #}
                   <gco:CharacterString>{{ instrument.type }}</gco:CharacterString>
@@ -934,7 +934,7 @@
 
                 {# description: mandatory #}
                 {% if instrument.description_other %}
-                <mac:description xsi:type="lan:PT_FreeText_PropertyType">
+                <mac:description>
                   {# CIOOS core mandatory element #}
                   {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/description/CharacterString #}
                   <gco:CharacterString>{{ instrument.description_other }}</gco:CharacterString>
@@ -951,14 +951,14 @@
                       <mac:identifier>
                         <mcc:MD_Identifier>
                           {# code: mandatory #}
-                          <mcc:code xsi:type="lan:PT_FreeText_PropertyType">
+                          <mcc:code>
                             {# CIOOS core mandatory element #}
                             {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/sensor/MI_Sensor/identifier/MD_Identifier/code/CharacterString #}
                             <gco:CharacterString>{{ sensor.id }}</gco:CharacterString>
                           </mcc:code>
                           {# version: mandatory #}
                           {% if sensor.version %}
-                          <mcc:version xsi:type="lan:PT_FreeText_PropertyType">
+                          <mcc:version>
                             {# CIOOS core mandatory element #}
                             {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/sensor/MI_Sensor/identifier/MD_Identifier/version/CharacterString #}
                             <gco:CharacterString>{{ sensor.version }}</gco:CharacterString>
@@ -966,7 +966,7 @@
                           {% endif %}
                           {% if sensor.description %}
                           {# description: mandatory #}
-                          <mcc:description xsi:type="lan:PT_FreeText_PropertyType">
+                          <mcc:description>
                             {# CIOOS core mandatory element #}
                             {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/sensor/MI_Sensor/identifier/MD_Identifier/description/CharacterString #}
                             <gco:CharacterString>{{ sensor.description }}</gco:CharacterString>

--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -515,7 +515,7 @@
                 {# verticalCRSId: CIOOS core mandatory #}
                 <gex:verticalCRSId>
                   <mrs:MD_ReferenceSystem>
-                    {# referenceSystemIdentifier: optional but dosn't make sense as referenceSystemType is mandatory #}
+                    {# referenceSystemIdentifier: optional #}
               			<mrs:referenceSystemIdentifier>
               				<mcc:MD_Identifier>
                         {# code: mandatory #}
@@ -813,7 +813,7 @@
     </mdb:metadataMaintenance>
 
   {% if record['platform_name'] %}
-  {# acquisitionInformation: mandatory #}
+  {# acquisitionInformation: Recomended #}
   <mdb:acquisitionInformation>
     <mac:MI_AcquisitionInformation>
       {# scope: CIOOS core mandatory #}
@@ -825,9 +825,8 @@
           </mcc:level>
         </mcc:MD_Scope>
       </mac:scope>
-      {# instrument: mandatory #}
 
-      {# platform: mandatory #}
+      {# platform: Recomended #}
       <mac:platform>
         <mac:MI_Platform>
 
@@ -885,11 +884,23 @@
           </mac:description>
 
           {% for num, instrument in instruments.items() %}
+            {# instrument: Recomended, if platform not used then this should be under mac:MI_AcquisitionInformation #}
             <mac:instrument>
+              {# MI_Instrument: Recomended #}
               <mac:MI_Instrument>
                 {# identifier: mandatory #}
                 <mac:identifier>
                   <mcc:MD_Identifier>
+                    {# authority: Recomended #}
+                    {% if instrument.manufacturer %}
+                    <mcc:authority>
+                      <cit:CI_Citation>
+                        <cit:title>
+                        <gco:CharacterString>{{ instrument.manufacturer }}</gco:CharacterString>
+                        </cit:title>
+                      </cit:CI_Citation>
+                    </mcc:authority>
+                    {% endif %}
                     {# code: mandatory #}
                     <mcc:code xsi:type="lan:PT_FreeText_PropertyType">
                       {# CIOOS core mandatory element #}
@@ -963,8 +974,11 @@
                           {% endif %}
                         </mcc:MD_Identifier>
                       </mac:identifier>
+                      <mac:type>
+                        {# type: mandatory #}
+                        <gco:CharacterString>{{ sensor.type }}</gco:CharacterString>
                       <mac:type/>
-                      {# hosted: mandatory #}
+                      {# hosted: optional #}
                       <mac:hosted>
                         {# mac:MI_Instrument is an association to parent MI_Instrument really needed in this case? #}
                       </mac:hosted>

--- a/sample_records/record.yaml
+++ b/sample_records/record.yaml
@@ -64,6 +64,7 @@ instrument_1_description_eng: instrument_1_description in english
 
 instrument_1_sensor_1_id: instrument_1_sensor_1_id
 instrument_1_sensor_1_version: instrument_1_sensor_1_version
+instrument_1_sensor_1_type: instrument_1_sensor_1_type
 instrument_1_sensor_1_description: instrument_1_sensor_1_description in french
 instrument_1_sensor_1_description_eng: instrument_1_sensor_1_description in english
 

--- a/sample_records/record.yaml
+++ b/sample_records/record.yaml
@@ -59,11 +59,13 @@ use_constraints: "use_constraints"
 instrument_1_id: instrument_1_id
 instrument_1_version: instrument_1_version
 instrument_1_type: instrument_1_type
-instrument_1_description: instrument_1_description
+instrument_1_description: instrument_1_description in french
+instrument_1_description_eng: instrument_1_description in english
 
 instrument_1_sensor_1_id: instrument_1_sensor_1_id
 instrument_1_sensor_1_version: instrument_1_sensor_1_version
-instrument_1_sensor_1_description: instrument_1_sensor_1_description
+instrument_1_sensor_1_description: instrument_1_sensor_1_description in french
+instrument_1_sensor_1_description_eng: instrument_1_sensor_1_description in english
 
 platform_name: "platform_name" # from cf
 platform_id: "platform_id" # from cf


### PR DESCRIPTION
Review platform / instrument / sensor metadata and compare to cioos metadata schema v1. moved some comments into issues in github. changed platform and instrument comment to indicate these fields are recommended in schema. Added authority (recommended) to instrument identifier and type (mandatory) to sensor.

remove xsi:type="lan:PT_FreeText_PropertyType" where it is not needed
