### PR TITLE
use indeterminatePosition=unknown when no time given (alternate solution)

### DIFF
--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -554,15 +554,24 @@
         </mri:extent>
       {% endif %}
 
-      {% if record['time_coverage_start'] and record['time_coverage_end'] %}
       <mri:extent>
         <gex:EX_Extent>
           <gex:temporalElement>
             <gex:EX_TemporalExtent>
               <gex:extent>
                 <gml:TimePeriod gml:id="time_period">
+                  {% if record['time_coverage_start'] %}
                   <gml:beginPosition>{{ record['time_coverage_start'] }}</gml:beginPosition>
+                  {% else %}
+                  <gml:beginPosition indeterminatePosition="unknown"/>
+                  {% endif %}
+
+                  {% if record['time_coverage_end'] %}
                   <gml:endPosition>{{ record['time_coverage_end'] }}</gml:endPosition>
+                  {% else %}
+                  <gml:endPosition indeterminatePosition="unknown"/>
+                  {% endif %}
+
                   {% if record['time_coverage_duration']  %}
                   <gml:duration>{{ record['time_coverage_duration'] }}</gml:duration>
                   {% endif %}
@@ -572,7 +581,6 @@
           </gex:temporalElement>
         </gex:EX_Extent>
       </mri:extent>
-      {% endif %}
 
       {# resourceMaintenance: CIOOS core mandatory #}
       {# refers to the maintenance of the data #}

--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -568,6 +568,8 @@
 
                   {% if record['time_coverage_end'] %}
                   <gml:endPosition>{{ record['time_coverage_end'] }}</gml:endPosition>
+                  {% elif not record['progress_code'] or record['progress_code'] == 'onGoing' %}
+                  <gml:endPosition indeterminatePosition="now"/>
                   {% else %}
                   <gml:endPosition indeterminatePosition="unknown"/>
                   {% endif %}


### PR DESCRIPTION
Alternate solution to PR #33 building on work by @fostermh . doesn't rely on `progress_code` and avoids duplicating the `temporalElement` block