### PR TITLE
remove mountedOn

### DIFF
--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -932,8 +932,6 @@
                   <gco:CharacterString>{{ instrument.type }}</gco:CharacterString>
                 </mac:type>
 
-                {# mountedOn: mandatory? #}
-                <mac:mountedOn/>
                 {% for sensor_num, sensor in instrument.sensor.items() %}
                   {# sensor: mandatory #}
                   <mac:sensor>


### PR DESCRIPTION
Resolves #36 . I think `mountedOn` was considered mandatory at some point but is no longer. Not needed for validation