### PR TITLE
remove instrument sensor fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,10 @@ See example .yaml files in the 'sample_records' directory for more examples.
 - title
 - use_constraints
 
-These can be repeated with different instrument/sensor numbers, eg:
+These can be repeated with different instrument numbers, eg:
 
 - instrument_1_id
 - instrument_1_description
 - instrument_1_description_other
 - instrument_1_type
 - instrument_1_version
-
-- instrument_1_sensor_1_id
-- instrument_1_sensor_1_description
-- instrument_1_sensor_1_version

--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -934,50 +934,7 @@
 
                 {# mountedOn: mandatory? #}
                 <mac:mountedOn/>
-                {% for sensor_num, sensor in instrument.sensor.items() %}
-                  {# sensor: mandatory #}
-                  <mac:sensor>
-                    <mac:MI_Sensor>
-
-                      {# identifier: mandatory #}
-                      <mac:identifier>
-                        <mcc:MD_Identifier>
-                          {# code: mandatory #}
-                          <mcc:code>
-                            {# CIOOS core mandatory element #}
-                            {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/sensor/MI_Sensor/identifier/MD_Identifier/code/CharacterString #}
-                            <gco:CharacterString>{{ sensor.id }}</gco:CharacterString>
-                          </mcc:code>
-                          {# version: mandatory #}
-                          {% if sensor.version %}
-                          <mcc:version>
-                            {# CIOOS core mandatory element #}
-                            {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/sensor/MI_Sensor/identifier/MD_Identifier/version/CharacterString #}
-                            <gco:CharacterString>{{ sensor.version }}</gco:CharacterString>
-                          </mcc:version>
-                          {% endif %}
-                          {% if sensor.description %}
-                          {# description: mandatory #}
-                          <mcc:description xsi:type="lan:PT_FreeText_PropertyType">
-                            {# CIOOS core mandatory element #}
-                            {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/sensor/MI_Sensor/identifier/MD_Identifier/description/CharacterString #}
-                            {{ multi_lang('instrument_' + instrument_num + '_sensor_' + sensor_num + '_description') }}
-                          </mcc:description>
-                          {% endif %}
-                        </mcc:MD_Identifier>
-                      </mac:identifier>
-                      <mac:type>
-                        {# type: mandatory #}
-                        <gco:CharacterString>{{ sensor.type }}</gco:CharacterString>
-                      </mac:type>
-                      {# hosted: optional #}
-                      <mac:hosted>
-                        {# mac:MI_Instrument is an association to parent MI_Instrument really needed in this case? #}
-                      </mac:hosted>
-                    </mac:MI_Sensor>
-                  </mac:sensor>
-                {% endfor %}
-              </mac:MI_Instrument>
+               </mac:MI_Instrument>
             </mac:instrument>
           {% endfor %}
         </mac:MI_Platform>

--- a/metadata_xml/iso_template.py
+++ b/metadata_xml/iso_template.py
@@ -35,18 +35,7 @@ def get_instruments_from_record(record):
 
         instrument_field = matches_instrument[2]
 
-        matches_sensor = re.search(r'^sensor_(\d)+_?(\w+)?', instrument_field)
-        if matches_sensor:
-            sensor_num = matches_sensor[1]
-            sensor_field = matches_sensor[2]
-            if 'sensor' not in instrument:
-                instrument['sensor'] = {}
-            if sensor_num not in instrument['sensor']:
-                instrument['sensor'][sensor_num] = {}
-
-            instrument['sensor'][sensor_num][sensor_field] = val
-        else:
-            instrument[instrument_field] = val
+        instrument[instrument_field] = val
 
     return instruments
 

--- a/metadata_xml/tests.py
+++ b/metadata_xml/tests.py
@@ -54,16 +54,10 @@ class TestISOTemplateFunctions(unittest.TestCase):
     def test_get_instruments_from_record(self):
         record = {
             "instrument_2_id": "instrument_2_id",
-            "instrument_2_sensor_1_id": "sensor_id",
         }
         self.assertEqual({
             '2': {
                 'id': 'instrument_2_id',
-                'sensor': {
-                    '1': {
-                        'id': 'sensor_id'
-                    }
-                }
             }
         }, get_instruments_from_record(record))
 

--- a/sample_records/record.yaml
+++ b/sample_records/record.yaml
@@ -62,12 +62,6 @@ instrument_1_type: instrument_1_type
 instrument_1_description: instrument_1_description in french
 instrument_1_description_eng: instrument_1_description in english
 
-instrument_1_sensor_1_id: instrument_1_sensor_1_id
-instrument_1_sensor_1_version: instrument_1_sensor_1_version
-instrument_1_sensor_1_type: instrument_1_sensor_1_type
-instrument_1_sensor_1_description: instrument_1_sensor_1_description in french
-instrument_1_sensor_1_description_eng: instrument_1_sensor_1_description in english
-
 platform_name: "platform_name" # from cf
 platform_id: "platform_id" # from cf
 platform_role: "owner"


### PR DESCRIPTION
Removes all references to the instrument sensor fields, eg `instrument_1_sensor_1_id`, as they are no longer in the CIOOS profile

Resolves #37 
Resolves #38 
