### PR TITLE
Fix date/datetime validation

### DIFF
--- a/metadata_xml/tests.py
+++ b/metadata_xml/tests.py
@@ -111,15 +111,17 @@ class TestISOTemplateFunctions(unittest.TestCase):
         self.assertEqual(list_intersection([1, 2], [2, 3]), [2])
 
     def test_check_date(self):
-        good_dates = ['20161022',
-                      '2010-09-28',
-                      '20140102T12:01:22',
+        good_dates = ['2020-01-21T21:31:58-07:00',
+                      '2020-01-21T21:31:58Z',
+                      '2020-01-21T21:31:58',
+                      '2020-01-21',
+                      '20200121'
                       ]
         bad_dates = ['Monday January 3rd, 2017', '2010-31-01']
         for date in good_dates:
-            self.assertTrue(check_date(date))
+            self.assertTrue(check_date(date), date)
         for date in bad_dates:
-            self.assertFalse(check_date(date))
+            self.assertFalse(check_date(date), date)
 
     def test_has_eov_in_keywords(self):
         record = {"language": "fra",

--- a/metadata_xml/validation.py
+++ b/metadata_xml/validation.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from datetime import datetime
+import arrow
 
 
 eovs = [
@@ -47,22 +47,17 @@ def strip_elements(lst):
     return [e.strip() for e in lst]
 
 
-acceptable_date_formats_text = ['YYYYMMDD', 'YYYY-MM-DD', 'YYYYMMDDThh:mm:ss',
-                                'YYYYMMDDThhmmss']
+acceptable_date_formats = [
+    # gco:Date
+    'YYYYMMDD', 'YYYY-MM-DD',
+    # gco:DateTime
+    'YYYY-MM-DDThh:mm:ss', 'YYYY-MM-DDThh:mm:ssZ', 'YYYY-MM-DDThh:mm:ssZZ']
 
 
 def check_date(date_text):
-    ''' gco:Date supports YYYYMMDD, YYYY-MM-DD
-        gco:DateTime supports YYYYMMDDThh:mm:ss, YYYYMMDDThhmmss,
-            or YYYY-MM-DDThh:mm:ss.
-    '''
-
-    acceptable_date_formats = ['%Y%m%d', '%Y-%m-%d', '%Y%m%dT%H:%M:%S',
-                               '%Y%m%dT%H%M%S']
-
     for date_format in acceptable_date_formats:
         try:
-            datetime.strptime(date_text, date_format)
+            arrow.parser.DateTimeParser().parse(date_text, date_format)
             return True
         except ValueError:
             continue
@@ -78,6 +73,7 @@ def get_fields_with_bad_dates(record):
         if field.startswith('date_') and record.get(field):
             if check_date(record.get(field)) is False:
                 bad_date_fields.append(field)
+    return bad_date_fields
 
 
 def join(lst):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(name='metadata_xml',
 
       install_requires=['Jinja2 == 2.10.3',
                         'lxml == 4.4.1',
-                        'PyYAML == 5.1.2'
+                        'PyYAML == 5.1.2',
+                        'arrow==0.15.5'
                         ]
 
       )


### PR DESCRIPTION
Date/DateTime validation wasn't allowing all possible formats. Switching date module from `datetime` to `arrow` as it has better ISO 8601 support