### PR TITLE
add script to run docker tests, describe in README

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,4 +6,4 @@ jobs:
       - checkout
 
       # build the application image
-      - run: docker build ./ --tag metadata_xml
+      - run: docker build .

--- a/README.md
+++ b/README.md
@@ -111,3 +111,13 @@ These can be repeated with different instrument/sensor numbers, eg:
 - instrument_1_sensor_1_id
 - instrument_1_sensor_1_description
 - instrument_1_sensor_1_version
+
+## Running tests
+
+```bash
+cd metadata_xml
+python -m unittest tests.py
+```
+
+Or if you have Docker installed, from this directory:
+`sh run_docker_tests.sh`

--- a/run_docker_tests.sh
+++ b/run_docker_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Run tests and schema validation using Docker if it's installed
+
+if [ -x "$(command -v docker)" ]; then
+   docker build --force-rm . -t metadata_xml && docker image rm metadata_xml
+else
+    echo "Docker is not installed"
+fi


### PR DESCRIPTION
I'm just making it easier to run the tests using docker (python tests and schema validation tests). This way it can be run with `sh run_docker_tests.sh`