### PR TITLE
add required (MC) field topicCategory

### DIFF
--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -439,6 +439,10 @@
           <gco:TM_PeriodDuration>{{ record['time_coverage_resolution'] }}</gco:TM_PeriodDuration>
         </mri:temporalResolution>
       {% endif %}
+ 
+      <mri:topicCategory>
+        <mri:MD_TopicCategoryCode>oceans</mri:MD_TopicCategoryCode>
+      </mri:topicCategory>
 
       {% if record['geospatial_lon_min'] and
       record['geospatial_lon_max'] and


### PR DESCRIPTION
I hardcoded a topic of `oceans` for the missing topicCategory field. We could add more fields (eg `environment`) but I looked through the long descriptions of each field and `oceans` seemed the only one that fit. ERDDAP hardcodes this value to `geoscientificInformation`

I went through the required fields using @odumidika's new site https://cioosatlantic.ca/profile/ and it seems that we have them all covered now.