### PR TITLE
change citedResponsibleParty->Role for creator_name to author

### DIFF
--- a/metadata_xml/cioos_template.jinja2
+++ b/metadata_xml/cioos_template.jinja2
@@ -371,7 +371,7 @@
             <cit:CI_Responsibility>
               {# role: mandatory #}
               <cit:role>
-                <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="originator"/>
+                <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="author"/>
                   {# CIOOS core mandatory element #}
                   {# MI_Metadata/identificationInfo/MD_DataIdentification/citation/CI_Citation/role/CI_RoleCode #}
               </cit:role>


### PR DESCRIPTION
`originator` is what is being used by CKAN to determine the organization name, so removing `originator` here