### PR TITLE
Split out template rendering code from __main__ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ eg:
 
 `python -m metadata_xml -f sample_records/record.yaml`
 
+## Importing into other Python projects
+
+You can perform the yaml to XML conversion in other projects this way:
+
+```python
+from metadata_xml.template_functions import metadata_to_xml
+
+record = {...}
+xml = metadata_to_xml(record)
+```
+
+and add to your requirements.txt:
+
+`git+git://github.com/cioos-siooc/metadata-xml.git`
+
 ## YAML Metadata format
 
 See `sample_records/record.yaml` for an example. Most text fields have the option to be bilingual, eg:

--- a/metadata_xml/__main__.py
+++ b/metadata_xml/__main__.py
@@ -9,7 +9,7 @@
  (eg, record.yaml -> record.xml)
 
 '''
-from metadata_xml.template_functions import render_template
+from metadata_xml.template_functions import metadata_to_xml
 import argparse
 import yaml
 import os
@@ -32,7 +32,7 @@ if __name__ == '__main__':
     basename = os.path.basename(filename)
     print("Input filename as: "+basename)
 
-    xml = render_template(record)
+    xml = metadata_to_xml(record)
 
     pre, ext = os.path.splitext(filename)
     yaml_filename = f'{pre}.xml'

--- a/metadata_xml/__main__.py
+++ b/metadata_xml/__main__.py
@@ -9,60 +9,10 @@
  (eg, record.yaml -> record.xml)
 
 '''
-
-
-from datetime import date
-import os
+from metadata_xml.template_functions import render_template
 import argparse
-import pathlib
 import yaml
-from jinja2 import Environment, FileSystemLoader
-
-dir_path = os.path.dirname(os.path.realpath(__file__))
-this_directory = pathlib.Path(__file__).parent.absolute()
-schema_path = os.path.join(this_directory, 'iso19115-cioos-template')
-
-
-def normalize_datestring(datestring, format_='default'):
-    """groks date string into ISO8601
-       Adopted from Pygeometa https: // github.com/geopython/pygeometa/blob/master/pygeometa/core.py
-    """
-
-    try:
-        if isinstance(datestring, date):
-            if datestring.year < 1900:
-                datestring2 = '{0.day:02d}.{0.month:02d}.{0.year:4d}'.format(
-                    datestring)
-            else:
-                datestring2 = datestring.strftime('%Y-%m-%dT%H:%M:%SZ')
-            if datestring2.endswith('T00:00:00Z'):
-                datestring2 = datestring2.replace('T00:00:00Z', '')
-            return datestring2
-        elif isinstance(datestring, int) and len(str(datestring)) == 4:  # year
-            return str(datestring)
-    except AttributeError:
-        raise RuntimeError('Invalid datestring: {}'.format(datestring))
-    return datestring
-
-
-def list_all_languages_in_record(record):
-    '''So that we can list all languages used in the otherLocale section of XML'''
-    def list_keys_in_dict(d, all_keys=[]):
-        # recursive function, works on nested dict for example
-        for k, v in d.items():
-            if isinstance(v, dict):
-                all_keys.append(k)
-                list_keys_in_dict(v, all_keys)
-            else:
-                all_keys.append(k)
-        return set(all_keys)
-
-    keys_in_record = list_keys_in_dict(record)
-
-    two_character_keys = list(
-        filter(lambda x: (len(x) == 2) and (x != 'id'), keys_in_record))
-    return two_character_keys
-
+import os
 
 if __name__ == '__main__':
 
@@ -82,16 +32,7 @@ if __name__ == '__main__':
     basename = os.path.basename(filename)
     print("Input filename as: "+basename)
 
-    template_loader = FileSystemLoader(searchpath=schema_path)
-    template_env = Environment(loader=template_loader, trim_blocks=True,
-                               lstrip_blocks=True)
-
-    template_env.globals.update(
-        list_all_languages_in_record=list_all_languages_in_record)
-    template_env.filters['normalize_datestring'] = normalize_datestring
-    template = template_env.get_template('main.j2')
-
-    xml = template.render({"record": record})
+    xml = render_template(record)
 
     pre, ext = os.path.splitext(filename)
     yaml_filename = f'{pre}.xml'

--- a/metadata_xml/template_functions.py
+++ b/metadata_xml/template_functions.py
@@ -1,0 +1,64 @@
+import pathlib
+
+from datetime import date
+import os
+
+from jinja2 import Environment, FileSystemLoader
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+this_directory = pathlib.Path(__file__).parent.absolute()
+schema_path = os.path.join(this_directory, 'iso19115-cioos-template')
+
+
+def normalize_datestring(datestring, format_='default'):
+    """groks date string into ISO8601
+       Adopted from Pygeometa https: // github.com/geopython/pygeometa/blob/master/pygeometa/core.py
+    """
+
+    try:
+        if isinstance(datestring, date):
+            if datestring.year < 1900:
+                datestring2 = '{0.day:02d}.{0.month:02d}.{0.year:4d}'.format(
+                    datestring)
+            else:
+                datestring2 = datestring.strftime('%Y-%m-%dT%H:%M:%SZ')
+            if datestring2.endswith('T00:00:00Z'):
+                datestring2 = datestring2.replace('T00:00:00Z', '')
+            return datestring2
+        elif isinstance(datestring, int) and len(str(datestring)) == 4:  # year
+            return str(datestring)
+    except AttributeError:
+        raise RuntimeError('Invalid datestring: {}'.format(datestring))
+    return datestring
+
+
+def list_all_languages_in_record(record):
+    '''So that we can list all languages used in the otherLocale section of XML'''
+    def list_keys_in_dict(d, all_keys=[]):
+        # recursive function, works on nested dict for example
+        for k, v in d.items():
+            if isinstance(v, dict):
+                all_keys.append(k)
+                list_keys_in_dict(v, all_keys)
+            else:
+                all_keys.append(k)
+        return set(all_keys)
+
+    keys_in_record = list_keys_in_dict(record)
+
+    two_character_keys = list(
+        filter(lambda x: (len(x) == 2) and (x != 'id'), keys_in_record))
+    return two_character_keys
+
+
+def render_template(record):
+    template_loader = FileSystemLoader(searchpath=schema_path)
+    template_env = Environment(loader=template_loader, trim_blocks=True,
+                               lstrip_blocks=True)
+
+    template_env.globals.update(
+        list_all_languages_in_record=list_all_languages_in_record)
+    template_env.filters['normalize_datestring'] = normalize_datestring
+    template = template_env.get_template('main.j2')
+
+    return template.render({"record": record})

--- a/metadata_xml/template_functions.py
+++ b/metadata_xml/template_functions.py
@@ -51,7 +51,7 @@ def list_all_languages_in_record(record):
     return two_character_keys
 
 
-def render_template(record):
+def metadata_to_xml(record):
     template_loader = FileSystemLoader(searchpath=schema_path)
     template_env = Environment(loader=template_loader, trim_blocks=True,
                                lstrip_blocks=True)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(name='metadata_xml',
       description='Python module for converting ACDD style metadata into the '
       + 'CIOOS ISO profile',
       url='https://github.com/cioos-siooc/metadata-xml',
-      packages=['metadata_xml', ],
+      packages=['metadata_xml'],
       include_package_data=True,
 
       install_requires=['Jinja2 == 2.10.3',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,11 @@ setup(name='metadata_xml',
       description='Python module for converting ACDD style metadata into the '
       + 'CIOOS ISO profile',
       url='https://github.com/cioos-siooc/metadata-xml',
-      packages=['metadata_xml'],
-      package_data={'metadata_xml': ['iso19115-cioos-template/*.j2']},
+      packages=['metadata_xml', ],
       include_package_data=True,
+
+      install_requires=['Jinja2 == 2.10.3',
+                        'PyYAML == 5.1.2',
+                        ]
+
       )

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,4 @@ setup(name='metadata_xml',
       packages=['metadata_xml'],
       package_data={'metadata_xml': ['iso19115-cioos-template/*.j2']},
       include_package_data=True,
-      install_requires=['pygeometa']
       )


### PR DESCRIPTION
I separated the code that converts from json (yaml) to XML away from `__main__.py` so that this transformation can be included/run in other projects that import this module more easily

Also removed a leftover reference to Pygeometa