### PR TITLE
add -o option to choose XML output folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv/
 .vscode
 .mypy*
 notforrepo
+*.xml

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It can be used as a command line tool, or imported into other Python code.
 
 To convert a Yaml file to XML, run:
 
-`python -m metadata_xml -f <yaml_file_path>`
+`python -m metadata_xml -f <yaml_file_path> -o <optional_destination_folder>`
 
 eg:
 

--- a/metadata_xml/__main__.py
+++ b/metadata_xml/__main__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-'''
+"""
 
  Code to handle command line usage of this module
  eg `python -m metadata_xml my_record.yaml`
@@ -8,7 +8,7 @@
  Creates an XML file with same base name as Yaml file
  (eg, record.yaml -> record.xml)
 
-'''
+"""
 import os
 import argparse
 import yaml
@@ -16,7 +16,7 @@ from metadata_xml.template_functions import metadata_to_xml
 
 
 def main():
-    'Handes argparse and calls metadata_to_xml()'
+    """Handles argparse and calls metadata_to_xml()"""
     parser = argparse.ArgumentParser(prog='metadata_xml',
                                      description="Convert yaml into CIOOS xml")
 
@@ -41,12 +41,13 @@ def main():
 
     xml = metadata_to_xml(record)
 
-    pre, ext = os.path.splitext(filename)
+    pre = os.path.splitext(basename)[0]
+    path_with_file = os.path.splitext(filename)[0]
 
     if output_folder:
         yaml_filename = f'{output_folder}/{pre}.xml'
     else:
-        yaml_filename = f'{pre}.xml'
+        yaml_filename = f'{path_with_file}.xml'
 
     file = open(yaml_filename, "w")
     file.write(xml)

--- a/metadata_xml/__main__.py
+++ b/metadata_xml/__main__.py
@@ -9,13 +9,14 @@
  (eg, record.yaml -> record.xml)
 
 '''
-from metadata_xml.template_functions import metadata_to_xml
+import os
 import argparse
 import yaml
-import os
+from metadata_xml.template_functions import metadata_to_xml
 
-if __name__ == '__main__':
 
+def main():
+    'Handes argparse and calls metadata_to_xml()'
     parser = argparse.ArgumentParser(prog='metadata_xml',
                                      description="Convert yaml into CIOOS xml")
 
@@ -23,8 +24,14 @@ if __name__ == '__main__':
         '-f', type=str, dest="yaml_file",
         help="Enter filename of yaml file.", required=True)
 
+    parser.add_argument(
+        '-o', type=str, dest="output_folder",
+        help="Enter the folder to write your xml file to." +
+        "Defaults to the source file's directory.", required=False)
+
     args = parser.parse_args()
     filename = args.yaml_file
+    output_folder = args.output_folder
 
     with open(args.yaml_file) as stream:
         record = yaml.safe_load(stream)
@@ -35,7 +42,16 @@ if __name__ == '__main__':
     xml = metadata_to_xml(record)
 
     pre, ext = os.path.splitext(filename)
-    yaml_filename = f'{pre}.xml'
+
+    if output_folder:
+        yaml_filename = f'{output_folder}/{pre}.xml'
+    else:
+        yaml_filename = f'{pre}.xml'
+
     file = open(yaml_filename, "w")
     file.write(xml)
     print("Wrote " + file.name)
+
+
+if __name__ == '__main__':
+    main()

--- a/metadata_xml/template_functions.py
+++ b/metadata_xml/template_functions.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
-'''
+"""
 
 Defines custom functions used by the Jinja template
 
 Also defines metadata_to_xml()
 
-'''
+"""
 
 import pathlib
 
@@ -42,10 +42,10 @@ def normalize_datestring(datestring):
 
 
 def list_all_languages_in_record(record):
-    '''Lists all languages used, so that we can list all
-    languages used in the otherLocale section of XML'''
-    def list_keys_in_record(record_subset, all_keys=[]):
-        'recursive function, works on nested dict for example'
+    """Lists all languages used, so that we can list all
+    languages used in the otherLocale section of XML"""
+    def list_keys_in_record(record_subset, all_keys):
+        """recursive function, works on nested dict for example"""
         for key, val in record_subset.items():
             if isinstance(val, dict):
                 all_keys.append(key)
@@ -54,7 +54,7 @@ def list_all_languages_in_record(record):
                 all_keys.append(key)
         return set(all_keys)
 
-    keys_in_record = list_keys_in_record(record)
+    keys_in_record = list_keys_in_record(record, [])
 
     two_character_keys = list(
         filter(lambda x: (len(x) == 2) and (x != 'id'), keys_in_record))
@@ -62,7 +62,7 @@ def list_all_languages_in_record(record):
 
 
 def metadata_to_xml(record):
-    'Runs steps needed to render the Jinja template'
+    """Runs steps needed to render the Jinja template"""
 
     this_directory = pathlib.Path(__file__).parent.absolute()
     schema_path = os.path.join(this_directory, SCHEMA_FOLDER_NAME)

--- a/metadata_xml/template_functions.py
+++ b/metadata_xml/template_functions.py
@@ -1,3 +1,13 @@
+#!/usr/bin/env python3
+
+'''
+
+Defines custom functions used by the Jinja template
+
+Also defines metadata_to_xml()
+
+'''
+
 import pathlib
 
 from datetime import date
@@ -5,14 +15,13 @@ import os
 
 from jinja2 import Environment, FileSystemLoader
 
-dir_path = os.path.dirname(os.path.realpath(__file__))
-this_directory = pathlib.Path(__file__).parent.absolute()
-schema_path = os.path.join(this_directory, 'iso19115-cioos-template')
+SCHEMA_FOLDER_NAME = 'iso19115-cioos-template'
 
 
-def normalize_datestring(datestring, format_='default'):
+def normalize_datestring(datestring):
     """groks date string into ISO8601
-       Adopted from Pygeometa https: // github.com/geopython/pygeometa/blob/master/pygeometa/core.py
+       Adopted from Pygeometa,
+       https://github.com/geopython/pygeometa/blob/master/pygeometa/core.py
     """
 
     try:
@@ -33,18 +42,19 @@ def normalize_datestring(datestring, format_='default'):
 
 
 def list_all_languages_in_record(record):
-    '''So that we can list all languages used in the otherLocale section of XML'''
-    def list_keys_in_dict(d, all_keys=[]):
-        # recursive function, works on nested dict for example
-        for k, v in d.items():
-            if isinstance(v, dict):
-                all_keys.append(k)
-                list_keys_in_dict(v, all_keys)
+    '''Lists all languages used, so that we can list all
+    languages used in the otherLocale section of XML'''
+    def list_keys_in_record(record_subset, all_keys=[]):
+        'recursive function, works on nested dict for example'
+        for key, val in record_subset.items():
+            if isinstance(val, dict):
+                all_keys.append(key)
+                list_keys_in_record(val, all_keys)
             else:
-                all_keys.append(k)
+                all_keys.append(key)
         return set(all_keys)
 
-    keys_in_record = list_keys_in_dict(record)
+    keys_in_record = list_keys_in_record(record)
 
     two_character_keys = list(
         filter(lambda x: (len(x) == 2) and (x != 'id'), keys_in_record))
@@ -52,6 +62,11 @@ def list_all_languages_in_record(record):
 
 
 def metadata_to_xml(record):
+    'Runs steps needed to render the Jinja template'
+
+    this_directory = pathlib.Path(__file__).parent.absolute()
+    schema_path = os.path.join(this_directory, SCHEMA_FOLDER_NAME)
+
     template_loader = FileSystemLoader(searchpath=schema_path)
     template_env = Environment(loader=template_loader, trim_blocks=True,
                                lstrip_blocks=True)


### PR DESCRIPTION
Just adding an option to put the generated XML into a specified folder. The other stuff in this PR are just minor changes to satisfy my linter. The `-o` is optional

eg:

`python -m metadata_xml -f sample_records/record.yml -o ./xml`