### PR TITLE
prettify xml, also seems to fix the issue of escaping single quotes

### DIFF
--- a/metadata_xml/__main__.py
+++ b/metadata_xml/__main__.py
@@ -9,7 +9,9 @@
  (eg, record.yaml -> record.xml)
 
 """
+
 import os
+
 import argparse
 import yaml
 from metadata_xml.template_functions import metadata_to_xml
@@ -39,7 +41,7 @@ def main():
     basename = os.path.basename(filename)
     print("Input filename as: "+basename)
 
-    xml = metadata_to_xml(record)
+    xml_string = metadata_to_xml(record)
 
     pre = os.path.splitext(basename)[0]
     path_with_file = os.path.splitext(filename)[0]
@@ -50,7 +52,7 @@ def main():
         yaml_filename = f'{path_with_file}.xml'
 
     file = open(yaml_filename, "w")
-    file.write(xml)
+    file.write(xml_string)
     print("Wrote " + file.name)
 
 

--- a/metadata_xml/iso19115-cioos-template/bilingual.j2
+++ b/metadata_xml/iso19115-cioos-template/bilingual.j2
@@ -1,7 +1,10 @@
-{% macro bilingual(element,key,mapping) -%}
-{% set value = mapping[key] %}
+{% macro bilingual(element,key,record_section) -%}
+{% set value = record_section[key] %}
 
-{% if value is not mapping %}
+{% if (value is not mapping) or (value.items()|length==1 and lang in value)  %}
+      {% if value is mapping %}
+          {% set value = value[lang] %}
+      {% endif %}
       {% if value|trim != "None" %}
       <{{ element }}>
         <gco:CharacterString>{{ value|e }}</gco:CharacterString>

--- a/metadata_xml/template_functions.py
+++ b/metadata_xml/template_functions.py
@@ -9,6 +9,7 @@ Also defines metadata_to_xml()
 """
 
 import pathlib
+import xml.dom.minidom
 
 from datetime import date
 import os
@@ -76,4 +77,8 @@ def metadata_to_xml(record):
     template_env.filters['normalize_datestring'] = normalize_datestring
     template = template_env.get_template('main.j2')
 
-    return template.render({"record": record})
+    xml_string = template.render({"record": record})
+    dom = xml.dom.minidom.parseString(xml_string)
+
+    pretty_xml_as_string = dom.toprettyxml(newl='').replace("\n\n", "\n")
+    return pretty_xml_as_string


### PR DESCRIPTION
This was meant to fix indent the XML more nicely, but also fixes the issue of single quotes being unnecessarily escaped.

This also fixes this situation :

```yaml
comment:
       en: a
```
results in -

```xml
   <gco:CharacterString>sfd</gco:CharacterString>
          <lan:PT_FreeText>
          </lan:PT_FreeText>
```

This generates an error as `PT_FreeText` can't be empty, it's empty because there's no text.

With this PR the `PT_FreeText` won't be generated