### PR TITLE
put contacts in their proper spots

### DIFF
--- a/metadata_xml/iso19115-cioos-template/contact.j2
+++ b/metadata_xml/iso19115-cioos-template/contact.j2
@@ -1,8 +1,8 @@
-{% macro get_contact(contact, role ,role_codelist_value) -%}
+{% macro get_contact(contact, role_codelist_value) -%}
 
 <cit:CI_Responsibility>
   <cit:role>
-    <cit:CI_RoleCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="{{ role_codelist_value }}">{{ role }}</cit:CI_RoleCode>
+    <cit:CI_RoleCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="{{ role_codelist_value }}"/>
   </cit:role>
   <cit:party>
   {% if contact['organization'] %}

--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -214,16 +214,6 @@
         <cit:CI_Citation>
           {# title: mandatory #}
           {{ bl.bilingual('cit:title','title', record['identification']) }}
-          
-          {% if record['identification']['identification'] %}
-          <cit:identifier>
-    		        <mcc:MD_Identifier>
-    		            <mcc:code>
-                      <gco:CharacterString>{{ record['identification']['identification'] }}</gco:CharacterString>
-                    </mcc:code>
-    		        </mcc:MD_Identifier>
-    		    </cit:identifier>
-          {% endif %}
 
           {% for c in record['contact'] %}
           {% for role in c['roles'] %}

--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -104,11 +104,13 @@
   </mdb:metadataScope>
   {# contact: mandatory #}
   {% for c in record['contact'] %}
-    {% for role in c.roles %}
-    <mdb:contact>
-            {{ contact.get_contact(c, role or 'pointOfContact; contact', role or 'pointOfContact') }}
-    </mdb:contact>
-    {% endfor %}
+      {% for role in c.roles %}
+        {% if role in ['custodian','pointOfContact']%}
+      <mdb:contact>
+              {{ contact.get_contact(c, role) }}
+      </mdb:contact>
+        {% endif %}
+      {% endfor %}
   {% endfor %}
 
   {# schema requires at least one mdb:dateInfo field #}
@@ -212,12 +214,22 @@
         <cit:CI_Citation>
           {# title: mandatory #}
           {{ bl.bilingual('cit:title','title', record['identification']) }}
+          
+          {% if record['identification']['identification'] %}
+          <cit:identifier>
+    		        <mcc:MD_Identifier>
+    		            <mcc:code>
+                      <gco:CharacterString>{{ record['identification']['identification'] }}</gco:CharacterString>
+                    </mcc:code>
+    		        </mcc:MD_Identifier>
+    		    </cit:identifier>
+          {% endif %}
 
           {% for c in record['contact'] %}
           {% for role in c['roles'] %}
-          {% if role in ['author','contributor','creator'] %}
+          {% if role not in ['custodian','pointOfContact','distributor'] %}
           <cit:citedResponsibleParty>
-            {{ contact.get_contact(c, role + '; contact', role) }}
+            {{ contact.get_contact(c, role) }}
           </cit:citedResponsibleParty>
           {% endif %}
           {% endfor %}
@@ -516,7 +528,7 @@
       <mrd:distributor>
         <mrd:MD_Distributor>
           <mrd:distributorContact>
-        {{ contact.get_contact(c, 'distributor; contact', 'distributor') }}
+        {{ contact.get_contact(c, 'distributor') }}
             </mrd:distributorContact>
         </mrd:MD_Distributor>
       </mrd:distributor>

--- a/sample_records/record.yml
+++ b/sample_records/record.yml
@@ -60,7 +60,7 @@ identification:
     fr: [project_a in french, project_b in french]
 contact:
   - roles:
-      - pointOfContact
+      - custodian
     organization:
       name: Environment Canada
       url: https://www.ec.gc.ca/


### PR DESCRIPTION
After this PR:
 - pointOfContact role changed to custodian

Also simplified the `get_contact` macro, copied how ONC's style on this -

From 
```xml
codeListValue="pointOfContact">pointOfContact</cit:CI_RoleCode>				
```
To 
```xml
codeListValue="pointOfContact"/>				
```

Fixes #69 