### PR TITLE
add DOI field (identification->identifier)

### DIFF
--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -215,12 +215,12 @@
 
           {% if record['identification']['identifier'] %}
           <cit:identifier>
-    		        <mcc:MD_Identifier>
-    		            <mcc:code>
-                      <gco:CharacterString>{{ record['identification']['identifier'] }}</gco:CharacterString>
-                    </mcc:code>
-    		        </mcc:MD_Identifier>
-    		    </cit:identifier>
+            <mcc:MD_Identifier>
+                <mcc:code>
+                  <gco:CharacterString>{{ record['identification']['identifier'] }}</gco:CharacterString>
+                </mcc:code>
+            </mcc:MD_Identifier>
+    		  </cit:identifier>
           {% endif %}
 
           {% for c in record['contact'] %}
@@ -437,7 +437,7 @@
               <cit:onlineResource>
                 <cit:CI_OnlineResource>
                   <cit:linkage>
-                      {{ key }}
+                      {{ key|e }}
                     </cit:linkage>
                   <cit:protocol>
                     <gco:CharacterString>WWW:LINK</gco:CharacterString>
@@ -489,7 +489,7 @@
               <cit:onlineResource>
                 <cit:CI_OnlineResource>
                   <cit:linkage>
-                    <gco:CharacterString>{{ licence['url'] }}</gco:CharacterString>
+                    <gco:CharacterString>{{ licence['url']|e }}</gco:CharacterString>
                   </cit:linkage>
                   <cit:protocol>
                     <gco:CharacterString>WWW:LINK</gco:CharacterString>

--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -213,6 +213,16 @@
           {# title: mandatory #}
           {{ bl.bilingual('cit:title','title', record['identification']) }}
 
+          {% if record['identification']['identifier'] %}
+          <cit:identifier>
+    		        <mcc:MD_Identifier>
+    		            <mcc:code>
+                      <gco:CharacterString>{{ record['identification']['identifier'] }}</gco:CharacterString>
+                    </mcc:code>
+    		        </mcc:MD_Identifier>
+    		    </cit:identifier>
+          {% endif %}
+
           {% for c in record['contact'] %}
           {% for role in c['roles'] %}
           {% if role in ['author','contributor','creator'] %}

--- a/sample_records/record.yml
+++ b/sample_records/record.yml
@@ -36,6 +36,7 @@ identification:
   title:
     en: title in english
     fr: title in french
+  identifier: http://dx.doi.org/10.1093/ajae/aaq063
 
   abstract:
     en: abstract in French


### PR DESCRIPTION
This adds a identification->identifier field, so that we can have a DOI field in the form and have it go somewhere. This is recommended in the CIOOS profile

Also added `|e` to escape a URL or two that didnt have that before