### PR TITLE
hardcode platform role to originator

### DIFF
--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -632,7 +632,7 @@
                     <cit:CI_Responsibility>
                       {# role: mandatory #}
                       <cit:role>
-                        <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="{{ record['platform']['role'] }}" />
+                        <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="originator" />
                         {# CIOOS core mandatory element #}
                           {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/platform/MI_Platform/identifier/MD_Identifier/authority/CI_Citation/citedResponsibleParty/CI_Responsibility/role/CI_RoleCode #}
                       </cit:role>

--- a/sample_records/record.yml
+++ b/sample_records/record.yml
@@ -99,7 +99,6 @@ distribution:
 
 platform:
   name: platform_name
-  role: platform_role
   authority: platform_authority
   id: platform id
   description: platform_description


### PR DESCRIPTION
CIOOS profile suggests hardcoding to 'resourceProvider or originator'

Fixes #70