### PR TITLE
add topic_category - defaults to "oceans"

### DIFF
--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -267,7 +267,7 @@
       </mri:temporalResolution>
       {% endif %}
       <mri:topicCategory>
-        <mri:MD_TopicCategoryCode>oceans</mri:MD_TopicCategoryCode>
+        <mri:MD_TopicCategoryCode>{{ record['identification'].get('topic_category') or "oceans" }}</mri:MD_TopicCategoryCode>
       </mri:topicCategory>
       {% if record['spatial']['bbox'] %}
       <mri:extent>

--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -266,9 +266,14 @@
         <gco:TM_PeriodDuration>{{ record['identification']['time_coverage_resolution'] }}</gco:TM_PeriodDuration>
       </mri:temporalResolution>
       {% endif %}
+      
+      {% set topic_categories = list_or_value_to_list(record['identification'].get('topic_category') or "oceans")  %}
+      {% for topic_category in topic_categories %}
       <mri:topicCategory>
-        <mri:MD_TopicCategoryCode>{{ record['identification'].get('topic_category') or "oceans" }}</mri:MD_TopicCategoryCode>
+        <mri:MD_TopicCategoryCode>{{ topic_category }}</mri:MD_TopicCategoryCode>
       </mri:topicCategory>
+      {% endfor %}
+      
       {% if record['spatial']['bbox'] %}
       <mri:extent>
         {% set bbox = record['spatial']['bbox'] %}

--- a/sample_records/record.yml
+++ b/sample_records/record.yml
@@ -41,6 +41,7 @@ identification:
   abstract:
     en: abstract in French
     fr: abstract in English
+  topic_category: elevation
   dates:
     creation: 2011-11-11
     publication: 2000-09-01T00:00:00Z


### PR DESCRIPTION
Adds `topic_category` which defaults to "oceans". It can be one of:
```'farming', 'biota', 'boundaries', 'climatologyMeteorologyAtmosphere', 'economy', 'elevation', 'environment', 'geoscientificInformation', 'health', 'imageryBaseMapsEarthCover', 'intelligenceMilitary', 'inlandWaters', 'location', 'oceans', 'planningCadastre', 'society', 'structure', 'transportation', 'utilitiesCommunication', 'extraTerrestrial', 'disaster'```

Fixes #82