### PR TITLE
Associated resource, autoescape

### DIFF
--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -47,7 +47,9 @@
       {% if record['metadata']['naming_authority'] %}
       <mcc:authority>
         <cit:CI_Citation>
-            {{ bl.bilingual('cit:title', 'naming_authority',record['metadata']) }}
+            <cit:title>	
+              <gco:CharacterString>{{ record['metadata']['naming_authority'] }}</gco:CharacterString>
+            </cit:title>	
           </cit:CI_Citation>
       </mcc:authority>
       {% endif %}

--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -116,7 +116,7 @@
 
   {# schema requires at least one mdb:dateInfo field #}
   {# dateInfo: mandatory #}
-  
+
         {% for date_type, date in record['metadata']['dates'].items() %}
           {% set datestamp = date|normalize_datestring %}
   <mdb:dateInfo>
@@ -227,7 +227,7 @@
         <cit:CI_Citation>
           {# title: mandatory #}
           {{ bl.bilingual('cit:title','title', record['identification']) }}
-          
+
           {# date pubished/revised isnt required #}
           {% if 'dates' in record['identification'] %}
           {% for date_type, date in record['identification']['dates'].items() %}
@@ -283,19 +283,48 @@
           {# MI_Metadata/identificationInfo/MD_DataIdentification/status/MD_ProgressCode #}
         </mcc:MD_ProgressCode>
       </mri:status>
+
+      {% if record['identification']['associated_resources']}
+      <mri:associatedResource>
+				<mri:MD_AssociatedResource>
+					<mri:name>
+						<cit:CI_Citation>
+							<cit:title>{{ record['identification']['associated_resources']['title'] }}</cit:title>
+              <cit:identifier>
+                <mcc:MD_Identifier>
+                  <mcc:authority>
+                    <gco:CharacterString>{{ record['identification']['associated_resources']['authority'] }}<gco:CharacterString>
+                  </mcc:authority>
+                  <mcc:code>
+                    <gco:CharacterString>{{ record['identification']['associated_resources']['code'] }}<gco:CharacterString>
+                  </mcc:code>
+                </mcc:MD_Identifier>
+              </cit:identifier>
+						</cit:CI_Citation>
+					</mri:name>
+					<mri:associationType>
+						<mri:DS_AssociationTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_AssociationTypeCode" codeListValue="{{ record['identification']['associated_resources']['association_type'] }}"></mri:DS_AssociationTypeCode>
+					</mri:associationType>
+					<mri:initiativeType>
+						<mri:DS_InitiativeTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_InitiativeTypeCode" codeListValue="{{ record['identification']['associated_resources']['initiative_type']  }}"></mri:DS_InitiativeTypeCode>
+					</mri:initiativeType>
+				</mri:MD_AssociatedResource>
+			</mri:associatedResource>
+      {% endif %}
+
       {% if record['identification']['time_coverage_resolution'] %}
       <mri:temporalResolution>
         <gco:TM_PeriodDuration>{{ record['identification']['time_coverage_resolution'] }}</gco:TM_PeriodDuration>
       </mri:temporalResolution>
       {% endif %}
-      
+
       {% set topic_categories = list_or_value_to_list(record['identification'].get('topic_category') or "oceans")  %}
       {% for topic_category in topic_categories %}
       <mri:topicCategory>
         <mri:MD_TopicCategoryCode>{{ topic_category }}</mri:MD_TopicCategoryCode>
       </mri:topicCategory>
       {% endfor %}
-      
+
       {% if record['spatial']['bbox'] %}
       <mri:extent>
         {% set bbox = record['spatial']['bbox'] %}
@@ -459,7 +488,7 @@
           {{ bl.bilingual('mmi:maintenanceNote', 'maintenance_note', record['metadata']) }}
         </mmi:MD_MaintenanceInformation>
       </mri:resourceMaintenance>
-      
+
       {# Adding a Government of Canada keyword  #}
       <mri:descriptiveKeywords>
         <mri:MD_Keywords>
@@ -533,7 +562,7 @@
         </mri:MD_Keywords>
       </mri:descriptiveKeywords>
       {% endif %}
-      
+
       {% if record['metadata'].get('use_constraints',{}).get('licence')%}
         {% set licence = record['metadata']['use_constraints']['licence'] %}
       {% else %}
@@ -606,7 +635,7 @@
 
 
       {% for distribution in record['distribution'] %}
-      
+
       {% if '/erddap' in distribution['url']%}
       <mrd:transferOptions>
         <mrd:MD_DigitalTransferOptions>
@@ -631,7 +660,7 @@
       </mrd:transferOptions>
 
       {% else %}
-      
+
       <mrd:transferOptions>
         <mrd:MD_DigitalTransferOptions>
           <mrd:onLine>
@@ -746,7 +775,7 @@
 
           {% for instrument in record['platform']['instruments'] %}
             {# instrument: Recommended, if platform not used then this should be under mac:MI_AcquisitionInformation #}
-          
+
           {{ instr.get_instrument(instrument) }}
 
           {% endfor %}
@@ -755,7 +784,7 @@
     </mac:MI_AcquisitionInformation>
   </mdb:acquisitionInformation>
   {% endif %}
-      
+
   {# If there are instruments outside of a platform #}
   {% if record['instruments']%}
     <mdb:acquisitionInformation>
@@ -769,7 +798,7 @@
             </mcc:level>
           </mcc:MD_Scope>
       </mac:scope>
-      
+
       {% for instrument in record['instruments'] %}
           {{ instr.get_instrument(instrument) }}
       {% endfor %}

--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -284,34 +284,6 @@
         </mcc:MD_ProgressCode>
       </mri:status>
 
-      {% if record['identification']['associated_resources']}
-      <mri:associatedResource>
-				<mri:MD_AssociatedResource>
-					<mri:name>
-						<cit:CI_Citation>
-							<cit:title>{{ record['identification']['associated_resources']['title'] }}</cit:title>
-              <cit:identifier>
-                <mcc:MD_Identifier>
-                  <mcc:authority>
-                    <gco:CharacterString>{{ record['identification']['associated_resources']['authority'] }}<gco:CharacterString>
-                  </mcc:authority>
-                  <mcc:code>
-                    <gco:CharacterString>{{ record['identification']['associated_resources']['code'] }}<gco:CharacterString>
-                  </mcc:code>
-                </mcc:MD_Identifier>
-              </cit:identifier>
-						</cit:CI_Citation>
-					</mri:name>
-					<mri:associationType>
-						<mri:DS_AssociationTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_AssociationTypeCode" codeListValue="{{ record['identification']['associated_resources']['association_type'] }}"></mri:DS_AssociationTypeCode>
-					</mri:associationType>
-					<mri:initiativeType>
-						<mri:DS_InitiativeTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_InitiativeTypeCode" codeListValue="{{ record['identification']['associated_resources']['initiative_type']  }}"></mri:DS_InitiativeTypeCode>
-					</mri:initiativeType>
-				</mri:MD_AssociatedResource>
-			</mri:associatedResource>
-      {% endif %}
-
       {% if record['identification']['time_coverage_resolution'] %}
       <mri:temporalResolution>
         <gco:TM_PeriodDuration>{{ record['identification']['time_coverage_resolution'] }}</gco:TM_PeriodDuration>
@@ -612,6 +584,36 @@
         </mco:MD_Constraints>
       </mri:resourceConstraints>
       {% endif %}
+
+      {% for associated_resources in record['identification']['associated_resources'] %}
+      <mri:associatedResource>
+				<mri:MD_AssociatedResource>
+					<mri:name>
+						<cit:CI_Citation>
+							{{ bl.bilingual('cit:title','title', associated_resources) }}
+              <cit:identifier>
+                <mcc:MD_Identifier>
+                  <mcc:authority>
+                    <cit:CI_Citation>
+                      {{ bl.bilingual('cit:title', 'authority',associated_resources) }}
+                    </cit:CI_Citation>
+                  </mcc:authority>
+                  <mcc:code>
+                    <gco:CharacterString>{{ associated_resources['code'] }}</gco:CharacterString>
+                  </mcc:code>
+                </mcc:MD_Identifier>
+              </cit:identifier>
+						</cit:CI_Citation>
+					</mri:name>
+					<mri:associationType>
+						<mri:DS_AssociationTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_AssociationTypeCode" codeListValue="{{ associated_resources['association_type'] }}"></mri:DS_AssociationTypeCode>
+					</mri:associationType>
+					<mri:initiativeType>
+						<mri:DS_InitiativeTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_InitiativeTypeCode" codeListValue="{{ associated_resources['initiative_type']  }}"></mri:DS_InitiativeTypeCode>
+					</mri:initiativeType>
+				</mri:MD_AssociatedResource>
+			</mri:associatedResource>
+      {% endfor %}
 
       {{ bl.bilingual('mri:supplementalInformation', 'comment', record['metadata']) }}
     </mri:MD_DataIdentification>

--- a/metadata_xml/template_functions.py
+++ b/metadata_xml/template_functions.py
@@ -80,7 +80,7 @@ def metadata_to_xml(record):
 
     template_loader = FileSystemLoader(searchpath=schema_path)
     template_env = Environment(
-        loader=template_loader, trim_blocks=True, lstrip_blocks=True
+        loader=template_loader, trim_blocks=True, lstrip_blocks=True, autoescape=True
     )
 
     template_env.globals.update(
@@ -90,8 +90,8 @@ def metadata_to_xml(record):
     template_env.filters["normalize_datestring"] = normalize_datestring
     template = template_env.get_template("main.j2")
 
-    xml_string = template.render({"record": record}).replace("\n\n", "\n")
+    xml_string = template.render({"record": record})
     dom = xml.dom.minidom.parseString(xml_string)
 
-    pretty_xml_as_string = dom.toprettyxml(newl="", encoding="utf-8").decode()
+    pretty_xml_as_string = dom.toprettyxml(newl="").replace("\n\n", "\n")
     return pretty_xml_as_string

--- a/metadata_xml/template_functions.py
+++ b/metadata_xml/template_functions.py
@@ -90,8 +90,8 @@ def metadata_to_xml(record):
     template_env.filters["normalize_datestring"] = normalize_datestring
     template = template_env.get_template("main.j2")
 
-    xml_string = template.render({"record": record})
+    xml_string = template.render({"record": record}).replace("\n\n", "\n")
     dom = xml.dom.minidom.parseString(xml_string)
 
-    pretty_xml_as_string = dom.toprettyxml(newl="").replace("\n\n", "\n")
+    pretty_xml_as_string = dom.toprettyxml(newl="", encoding="utf-8").decode()
     return pretty_xml_as_string

--- a/sample_records/record.yml
+++ b/sample_records/record.yml
@@ -45,12 +45,12 @@ identification:
     fr: abstract in french
   associated_resources:
     - title:
-      en: associated resource title in english
-      fr: associated resource title in french
-    authority: ca.cioos
-    code: 26443ab2-964f-4031-a53b-f132434573e8
-    association_type: crossReference
-    initiative_type: study
+        en: associated resource title in english
+        fr: associated resource title in french
+      authority: ca.cioos
+      code: 26443ab2-964f-4031-a53b-f132434573e8
+      association_type: crossReference
+      initiative_type: study
   topic_category: elevation
   dates:
     publication: 2000-09-01T00:00:00Z

--- a/sample_records/record.yml
+++ b/sample_records/record.yml
@@ -41,8 +41,16 @@ identification:
   identifier: http://dx.doi.org/10.1093/ajae/aaq063
 
   abstract:
-    en: abstract in French
-    fr: abstract in English
+    en: abstract in english
+    fr: abstract in french
+  associated_resources:
+    - title:
+      en: associated resource title in english
+      fr: associated resource title in french
+    authority: ca.cioos
+    code: 26443ab2-964f-4031-a53b-f132434573e8
+    association_type: crossReference
+    initiative_type: study
   topic_category: elevation
   dates:
     publication: 2000-09-01T00:00:00Z

--- a/sample_records/record.yml
+++ b/sample_records/record.yml
@@ -8,9 +8,7 @@
 #
 
 metadata:
-  naming_authority:
-    en: namingauthority in en
-    fr: namingauthority in fr
+  naming_authority: ca.cioos
   identifier: 3f342f64-9348-11df-ba6a-0014c2c00eab
   language: en
   maintenance_note: maintenance_note
@@ -21,7 +19,9 @@ metadata:
       code: CC-BY-4.0
       url: https://creativecommons.org/licenses/by/4.0/
 
-  comment: just in the main language
+  comment:
+    en: comment in english
+    fr: comment in french
 
   history:
     en: history in english


### PR DESCRIPTION
This PR:
- adds @fostermh's associated records changes
- autoescape all fields which fixes a bug where ampersands in the input data cause invalid xml
-  naming authority shouldn't be bilingual