### PR TITLE
Fix newlines issue

### DIFF
--- a/metadata_xml/iso19115-cioos-template/bilingual.j2
+++ b/metadata_xml/iso19115-cioos-template/bilingual.j2
@@ -7,20 +7,20 @@
       {% endif %}
       {% if value|trim != "None" %}
       <{{ element }}>
-        <gco:CharacterString>{{ value|e }}</gco:CharacterString>
+        <gco:CharacterString>{{- value|e -}}</gco:CharacterString>
       </{{ element }}>
       {% endif %}
 {% else %}
       <{{ element }} xsi:type="lan:PT_FreeText_PropertyType">
 
       {% if value[lang]|trim != "None" %}
-        <gco:CharacterString>{{ value[lang]|e }}</gco:CharacterString>
+        <gco:CharacterString>{{- value[lang]|e -}}</gco:CharacterString>
     {% endif %}
           <lan:PT_FreeText>
           {% for secondary_lang,val in value.items() %}
           {% if secondary_lang != lang %}
             <lan:textGroup>
-              <lan:LocalisedCharacterString locale="#{{secondary_lang}}">{{ val|e }}</lan:LocalisedCharacterString>
+              <lan:LocalisedCharacterString locale="#{{secondary_lang}}">{{- val|e -}}</lan:LocalisedCharacterString>
             </lan:textGroup>
           {% endif %}
           {% endfor %}
@@ -42,7 +42,7 @@
         {% if default_lang_list|length>0 %}
           {% for keyword in default_lang_list %}
               <mri:keyword>
-                    <gco:CharacterString>{{ keyword|e }}</gco:CharacterString>
+                    <gco:CharacterString>{{- keyword|e -}}</gco:CharacterString>
               </mri:keyword>
           {% endfor %}
           {% endif %}
@@ -55,7 +55,7 @@
                 <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
                   <lan:PT_FreeText>
                     <lan:textGroup>
-                      <lan:LocalisedCharacterString locale="#{{ secondary_lang }}">{{ keyword|e }}</lan:LocalisedCharacterString>
+                      <lan:LocalisedCharacterString locale="#{{- secondary_lang -}}">{{- keyword|e -}}</lan:LocalisedCharacterString>
                     </lan:textGroup>
                   </lan:PT_FreeText>
                 </mri:keyword>

--- a/metadata_xml/iso19115-cioos-template/contact.j2
+++ b/metadata_xml/iso19115-cioos-template/contact.j2
@@ -2,30 +2,30 @@
 
 <cit:CI_Responsibility>
   <cit:role>
-    <cit:CI_RoleCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="{{ role_codelist_value }}"/>
+    <cit:CI_RoleCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="{{- role_codelist_value -}}"/>
   </cit:role>
   <cit:party>
   {% if contact['organization'] %}
     <cit:CI_Organisation>
-    {{ bl.bilingual('cit:name', 'name', contact['organization']) }}
+    {{- bl.bilingual('cit:name', 'name', contact['organization']) -}}
       <cit:contactInfo>
         <cit:CI_Contact>
           <cit:phone>
             <cit:CI_Telephone>
               <cit:number>
-              <gco:CharacterString>{{ contact['organization']['phone'] }}</gco:CharacterString>
+              <gco:CharacterString>{{- contact['organization']['phone'] -}}</gco:CharacterString>
               </cit:number>
             </cit:CI_Telephone>
           </cit:phone>
 
           <cit:address>
             <cit:CI_Address>
-              {{ bl.bilingual('cit:deliveryPoint', 'address', contact['organization']) }}
-              {{ bl.bilingual('cit:city', 'city', contact['organization']) }}
-              {{ bl.bilingual('cit:country', 'country', contact['organization']) }}
+              {{- bl.bilingual('cit:deliveryPoint', 'address', contact['organization']) -}}
+              {{- bl.bilingual('cit:city', 'city', contact['organization']) -}}
+              {{- bl.bilingual('cit:country', 'country', contact['organization']) -}}
               {% if contact['organization']['email'] %}
               <cit:electronicMailAddress>
-                <gco:CharacterString>{{ contact['organization']['email'] }}</gco:CharacterString>
+                <gco:CharacterString>{{- contact['organization']['email'] -}}</gco:CharacterString>
               </cit:electronicMailAddress>
               {% endif %}
             </cit:CI_Address>
@@ -34,7 +34,7 @@
           <cit:onlineResource>
             <cit:CI_OnlineResource>
               <cit:linkage>
-                <gco:CharacterString>{{ contact['organization']['url']|e }}</gco:CharacterString>
+                <gco:CharacterString>{{- contact['organization']['url']|e -}}</gco:CharacterString>
               </cit:linkage>
               <cit:protocol>
                 <gco:CharacterString>WWW:LINK</gco:CharacterString>
@@ -49,14 +49,14 @@
       
       {% if contact['individual'] %}
       <cit:individual>
-        {{ get_individual(contact['individual']) }}
+        {{- get_individual(contact['individual']) -}}
       </cit:individual>
       {% endif %}
 
     </cit:CI_Organisation>
     {% else %}
 
-    {{ get_individual(contact['individual']) }}
+    {{- get_individual(contact['individual']) -}}
 
     {% endif %}
 
@@ -70,18 +70,18 @@
 {% macro get_individual(contact) -%}
 
  <cit:CI_Individual>
-    {{ bl.bilingual('cit:name', 'name', contact) }}
+    {{- bl.bilingual('cit:name', 'name', contact) -}}
     <cit:contactInfo>
       <cit:CI_Contact>
         {% if contact['city'] or contact['country'] or contact['email']%}
         <cit:address>
           <cit:CI_Address>
-            {{ bl.bilingual('cit:deliveryPoint', 'address', contact) }}
-            {{ bl.bilingual('cit:city', 'city', contact) }}
-            {{ bl.bilingual('cit:country', 'country', contact) }}
+            {{- bl.bilingual('cit:deliveryPoint', 'address', contact) -}}
+            {{- bl.bilingual('cit:city', 'city', contact) -}}
+            {{- bl.bilingual('cit:country', 'country', contact) -}}
             {% if contact['email'] %}
             <cit:electronicMailAddress>
-              <gco:CharacterString>{{ contact['email'] }}</gco:CharacterString>
+              <gco:CharacterString>{{- contact['email'] -}}</gco:CharacterString>
             </cit:electronicMailAddress>
             {% endif %}
           </cit:CI_Address>
@@ -89,12 +89,12 @@
         {% endif %}
         {% if contact['contactType'] %}
         <cit:contactType>
-          <gco:CharacterString>{{ contact['contactType'] }}</gco:CharacterString>
+          <gco:CharacterString>{{- contact['contactType'] -}}</gco:CharacterString>
         </cit:contactType>
         {% endif %}
       </cit:CI_Contact>
     </cit:contactInfo>
-    {{ bl.bilingual('cit:positionName', 'position', contact) }}
+    {{- bl.bilingual('cit:positionName', 'position', contact) -}}
 </cit:CI_Individual>
 
 {% endmacro%}

--- a/metadata_xml/iso19115-cioos-template/instrument.j2
+++ b/metadata_xml/iso19115-cioos-template/instrument.j2
@@ -11,7 +11,7 @@
             {% if instrument['manufacturer'] %}
           <mcc:authority>
             <cit:CI_Citation>
-              {{ bl.bilingual('cit:title', 'manufacturer', instrument ) }}
+              {{- bl.bilingual('cit:title', 'manufacturer', instrument ) -}}
               </cit:CI_Citation>
           </mcc:authority>
           {% endif %}
@@ -19,26 +19,26 @@
           <mcc:code>
             {# CIOOS core mandatory element #}
               {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/identifier/MD_Identifier/code/CharacterString #}
-            <gco:CharacterString>{{ instrument.id }}</gco:CharacterString>
+            <gco:CharacterString>{{- instrument.id -}}</gco:CharacterString>
           </mcc:code>
           {% if instrument.version %}
             {# version: mandatory #}
           <mcc:version>
             {# CIOOS core mandatory element #}
               {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/identifier/MD_Identifier/version/CharacterString #}
-            <gco:CharacterString>{{ instrument.version }}</gco:CharacterString>
+            <gco:CharacterString>{{- instrument.version -}}</gco:CharacterString>
           </mcc:version>
           {% endif %}
             {# description: mandatory #}
               {# CIOOS core mandatory element #}
               {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/identifier/MD_Identifier/description/CharacterString #}                   
-            {{ bl.bilingual('mcc:description', 'description', instrument ) }}
+            {{- bl.bilingual('mcc:description', 'description', instrument ) -}}
         </mcc:MD_Identifier>
       </mac:identifier>
       {# type: mandatory #}
           {# CIOOS core mandatory element #}
           {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/instrument/MI_Instrument/type/CharacterString #}
-        {{ bl.bilingual('mac:type', 'type', instrument ) }}
+        {{- bl.bilingual('mac:type', 'type', instrument ) -}}
     </mac:MI_Instrument>
   </mac:instrument>
 {% endmacro %}

--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -48,7 +48,7 @@
       <mcc:authority>
         <cit:CI_Citation>
             <cit:title>	
-              <gco:CharacterString>{{ record['metadata']['naming_authority'] }}</gco:CharacterString>
+              <gco:CharacterString>{{- record['metadata']['naming_authority'] -}}</gco:CharacterString>
             </cit:title>	
           </cit:CI_Citation>
       </mcc:authority>
@@ -59,7 +59,7 @@
       <mcc:code>
         {# CIOOS core mandatory element #}
         {# MI_Metadata/metadataIdentifier/MD_Identifier/code/CharacterString #}
-        <gco:CharacterString>{{ record['metadata']['identifier'] }}</gco:CharacterString>
+        <gco:CharacterString>{{- record['metadata']['identifier'] -}}</gco:CharacterString>
       </mcc:code>
       {% endif %}
     </mcc:MD_Identifier>
@@ -72,7 +72,7 @@
     <lan:PT_Locale>
       {# language: mandatory #}
       <lan:language>
-        <lan:LanguageCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/lan/LanguageCode.xml" codeListValue="{{ lang_code  }}">
+        <lan:LanguageCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/lan/LanguageCode.xml" codeListValue="{{- lang_code  -}}">
           {# CIOOS core mandatory element #}
           {# MI_Metadata/defaultLocale/PT_Locale/language/LanguageCode (ISO639-2) #}
         </lan:LanguageCode>
@@ -110,7 +110,7 @@
       {% for role in c.roles %}
         {% if role in ['custodian','pointOfContact']%}
       <mdb:contact>
-              {{ contact.get_contact(c, role) }}
+              {{- contact.get_contact(c, role) -}}
       </mdb:contact>
         {% endif %}
       {% endfor %}
@@ -126,13 +126,13 @@
       {# date: mandatory #}
       <cit:date>
         {% if datestamp|length > 11 %}
-        <gco:DateTime>{{ datestamp }}</gco:DateTime>
+        <gco:DateTime>{{- datestamp -}}</gco:DateTime>
         {% else %}
-        <gco:Date>{{ datestamp }}</gco:Date>
+        <gco:Date>{{- datestamp -}}</gco:Date>
         {% endif %}
       </cit:date>
       <cit:dateType>
-        <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="{{ date_type }}">{{ date_type }}</cit:CI_DateTypeCode>
+        <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="{{- date_type -}}">{{- date_type -}}</cit:CI_DateTypeCode>
       </cit:dateType>
     </cit:CI_Date>
   </mdb:dateInfo>
@@ -200,7 +200,7 @@
     <lan:PT_Locale>
       {# language: mandatory #}
       <lan:language>
-        <lan:LanguageCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/lan/LanguageCode.xml" codeListValue="{{ alternate_lang_code }}">
+        <lan:LanguageCode codeList="http://standards.iso.org/iso/19115/resources/Codelist/lan/LanguageCode.xml" codeListValue="{{- alternate_lang_code -}}">
           {# CIOOS core mandatory element #}
           {# MI_Metadata/otherLocale/PT_Locale/language/LanguageCode (ISO639-2) #}
         </lan:LanguageCode>
@@ -228,7 +228,7 @@
       <mri:citation>
         <cit:CI_Citation>
           {# title: mandatory #}
-          {{ bl.bilingual('cit:title','title', record['identification']) }}
+          {{- bl.bilingual('cit:title','title', record['identification']) -}}
 
           {# date pubished/revised isnt required #}
           {% if 'dates' in record['identification'] %}
@@ -238,13 +238,13 @@
             <cit:CI_Date>
               <cit:date>
                 {% if datestamp|length > 11 %}
-                <gco:DateTime>{{ datestamp }}</gco:DateTime>
+                <gco:DateTime>{{- datestamp -}}</gco:DateTime>
                 {% else %}
-                <gco:Date>{{ datestamp }}</gco:Date>
+                <gco:Date>{{- datestamp -}}</gco:Date>
                 {% endif %}
               </cit:date>
               <cit:dateType>
-                <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="{{ date_type }}">{{ date_type }}</cit:CI_DateTypeCode>
+                <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="{{- date_type -}}">{{- date_type -}}</cit:CI_DateTypeCode>
               </cit:dateType>
             </cit:CI_Date>
           </cit:date>
@@ -255,7 +255,7 @@
           <cit:identifier>
             <mcc:MD_Identifier>
                 <mcc:code>
-                  <gco:CharacterString>{{ record['identification']['identifier'] }}</gco:CharacterString>
+                  <gco:CharacterString>{{- record['identification']['identifier'] -}}</gco:CharacterString>
                 </mcc:code>
             </mcc:MD_Identifier>
     		  </cit:identifier>
@@ -265,7 +265,7 @@
           {% for role in c['roles'] %}
           {% if role not in ['custodian','pointOfContact','distributor'] %}
           <cit:citedResponsibleParty>
-            {{ contact.get_contact(c, role) }}
+            {{- contact.get_contact(c, role) -}}
           </cit:citedResponsibleParty>
           {% endif %}
           {% endfor %}
@@ -277,10 +277,10 @@
       {# abstract: mandatory #}
         {# CIOOS core mandatory element #}
         {# MI_Metadata/identificationInfo/MD_DataIdentification/abstract/CharacterString #}
-      {{ bl.bilingual('mri:abstract', 'abstract', record['identification']) }}
-      {{ bl.bilingual('mri:credit', 'acknowledgement', record['identification']) }}
+      {{- bl.bilingual('mri:abstract', 'abstract', record['identification']) -}}
+      {{- bl.bilingual('mri:credit', 'acknowledgement', record['identification']) -}}
       <mri:status>
-        <mcc:MD_ProgressCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ProgressCode" codeListValue="{{ record['identification']['progress_code'] or 'onGoing' }}">
+        <mcc:MD_ProgressCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ProgressCode" codeListValue="{{- record['identification']['progress_code'] or 'onGoing' -}}">
           {# CIOOS core mandatory element #}
           {# MI_Metadata/identificationInfo/MD_DataIdentification/status/MD_ProgressCode #}
         </mcc:MD_ProgressCode>
@@ -288,14 +288,14 @@
 
       {% if record['identification']['time_coverage_resolution'] %}
       <mri:temporalResolution>
-        <gco:TM_PeriodDuration>{{ record['identification']['time_coverage_resolution'] }}</gco:TM_PeriodDuration>
+        <gco:TM_PeriodDuration>{{- record['identification']['time_coverage_resolution'] -}}</gco:TM_PeriodDuration>
       </mri:temporalResolution>
       {% endif %}
 
       {% set topic_categories = list_or_value_to_list(record['identification'].get('topic_category') or "oceans")  %}
       {% for topic_category in topic_categories %}
       <mri:topicCategory>
-        <mri:MD_TopicCategoryCode>{{ topic_category }}</mri:MD_TopicCategoryCode>
+        <mri:MD_TopicCategoryCode>{{- topic_category -}}</mri:MD_TopicCategoryCode>
       </mri:topicCategory>
       {% endfor %}
 
@@ -310,16 +310,16 @@
                 <gco:Boolean>true</gco:Boolean>
               </gex:extentTypeCode>
               <gex:westBoundLongitude>
-                <gco:Decimal>{{ bbox[0] }}</gco:Decimal>
+                <gco:Decimal>{{- bbox[0] -}}</gco:Decimal>
               </gex:westBoundLongitude>
               <gex:eastBoundLongitude>
-                <gco:Decimal>{{ bbox[2] }}</gco:Decimal>
+                <gco:Decimal>{{- bbox[2] -}}</gco:Decimal>
               </gex:eastBoundLongitude>
               <gex:southBoundLatitude>
-                <gco:Decimal>{{ bbox[1] }}</gco:Decimal>
+                <gco:Decimal>{{- bbox[1] -}}</gco:Decimal>
               </gex:southBoundLatitude>
               <gex:northBoundLatitude>
-                <gco:Decimal>{{ bbox[3] }}</gco:Decimal>
+                <gco:Decimal>{{- bbox[3] -}}</gco:Decimal>
               </gex:northBoundLatitude>
             </gex:EX_GeographicBoundingBox>
           </gex:geographicElement>
@@ -342,7 +342,7 @@
                   <gml:exterior>
                     <gml:LinearRing>
                       <gml:coordinates>
-                        {{ record['spatial']['polygon'] }}
+                        {{- record['spatial']['polygon'] -}}
                       </gml:coordinates>
                     </gml:LinearRing>
                   </gml:exterior>
@@ -359,10 +359,10 @@
           <gex:verticalElement>
             <gex:EX_VerticalExtent>
               <gex:minimumValue>
-                <gco:Real>{{ record['spatial']['vertical'][0] }}</gco:Real>
+                <gco:Real>{{- record['spatial']['vertical'][0] -}}</gco:Real>
               </gex:minimumValue>
               <gex:maximumValue>
-                <gco:Real>{{ record['spatial']['vertical'][1] }}</gco:Real>
+                <gco:Real>{{- record['spatial']['vertical'][1] -}}</gco:Real>
               </gex:maximumValue>
               {# verticalCRSId: CIOOS core mandatory #}
               <gex:verticalCRSId>
@@ -429,13 +429,13 @@
               <gex:extent>
                 <gml:TimePeriod gml:id="time_period">
                   {% if record['identification']['temporal_begin'] %}
-                  <gml:beginPosition>{{ record['identification']['temporal_begin'] }}</gml:beginPosition>
+                  <gml:beginPosition>{{- record['identification']['temporal_begin'] -}}</gml:beginPosition>
                   {% else %}
                   <gml:beginPosition indeterminatePosition="unknown" />
                   {% endif %}
 
                   {% if record['identification']['temporal_end'] %}
-                  <gml:endPosition>{{ record['identification']['temporal_end'] }}</gml:endPosition>
+                  <gml:endPosition>{{- record['identification']['temporal_end'] -}}</gml:endPosition>
                   {% elif not record['identification']['progress_code'] or record['identification']['progress_code'] == 'onGoing' %}
                   <gml:endPosition indeterminatePosition="now" />
                   {% else %}
@@ -443,7 +443,7 @@
                   {% endif %}
 
                   {% if record['identification']['temporal_duration']  %}
-                  <gml:duration>{{ record['identification']['temporal_duration'] }}</gml:duration>
+                  <gml:duration>{{- record['identification']['temporal_duration'] -}}</gml:duration>
                   {% endif %}
                 </gml:TimePeriod>
               </gex:extent>
@@ -459,7 +459,7 @@
           <mmi:maintenanceAndUpdateFrequency>
             <mmi:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_MaintenanceFrequencyCode" codeListValue="asNeeded">asNeeded</mmi:MD_MaintenanceFrequencyCode>
           </mmi:maintenanceAndUpdateFrequency>
-          {{ bl.bilingual('mmi:maintenanceNote', 'maintenance_note', record['metadata']) }}
+          {{- bl.bilingual('mmi:maintenanceNote', 'maintenance_note', record['metadata']) -}}
         </mmi:MD_MaintenanceInformation>
       </mri:resourceMaintenance>
 
@@ -498,20 +498,20 @@
 
         <mri:MD_Keywords>
           {% set keywords_xml = bl.bilingual_keyword_list(value) %}
-          {{ keywords_xml }}
+          {{- keywords_xml -}}
 
           {% if keywords_xml|trim|length>0 %}
           <mri:thesaurusName>
             <cit:CI_Citation>
               {# validation requires title #}
               <cit:title>
-                <gco:CharacterString>{{ key }}</gco:CharacterString>
+                <gco:CharacterString>{{- key -}}</gco:CharacterString>
               </cit:title>
               {% if key.startswith('http') %}
               <cit:onlineResource>
                 <cit:CI_OnlineResource>
                   <cit:linkage>
-                      {{ key|e }}
+                      {{- key|e -}}
                     </cit:linkage>
                   <cit:protocol>
                     <gco:CharacterString>WWW:LINK</gco:CharacterString>
@@ -529,7 +529,7 @@
       {% if record['identification']['project'] %}
       <mri:descriptiveKeywords>
         <mri:MD_Keywords>
-          {{ bl.bilingual_keyword_list(record['identification']['project']) }}
+          {{- bl.bilingual_keyword_list(record['identification']['project']) -}}
           <mri:type>
             <mri:MD_KeywordTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode" codeListValue="project">project</mri:MD_KeywordTypeCode>
           </mri:type>
@@ -551,19 +551,19 @@
           <mco:reference>
             <cit:CI_Citation>
               <cit:title>
-                <gco:CharacterString>{{ licence['title'] }}</gco:CharacterString>
+                <gco:CharacterString>{{- licence['title'] -}}</gco:CharacterString>
               </cit:title>
               <cit:identifier>
                 <mcc:MD_Identifier>
                   <mcc:code>
-                    <gco:CharacterString>{{ licence['code'] }}</gco:CharacterString>
+                    <gco:CharacterString>{{- licence['code'] -}}</gco:CharacterString>
                   </mcc:code>
                 </mcc:MD_Identifier>
               </cit:identifier>
               <cit:onlineResource>
                 <cit:CI_OnlineResource>
                   <cit:linkage>
-                    <gco:CharacterString>{{ licence['url']|e }}</gco:CharacterString>
+                    <gco:CharacterString>{{- licence['url']|e -}}</gco:CharacterString>
                   </cit:linkage>
                   <cit:protocol>
                     <gco:CharacterString>WWW:LINK</gco:CharacterString>
@@ -582,7 +582,7 @@
         {# MD_Constraints: CIOOS core mandatory #}
         <mco:MD_Constraints>
           {# useLimitation: CIOOS core mandatory #}
-           {{ bl.bilingual('mco:useLimitation', 'limitations', record['metadata']['use_constraints']) }}
+           {{- bl.bilingual('mco:useLimitation', 'limitations', record['metadata']['use_constraints']) -}}
         </mco:MD_Constraints>
       </mri:resourceConstraints>
       {% endif %}
@@ -592,32 +592,32 @@
 				<mri:MD_AssociatedResource>
 					<mri:name>
 						<cit:CI_Citation>
-							{{ bl.bilingual('cit:title','title', associated_resources) }}
+							{{- bl.bilingual('cit:title','title', associated_resources) -}}
               <cit:identifier>
                 <mcc:MD_Identifier>
                   <mcc:authority>
                     <cit:CI_Citation>
-                      {{ bl.bilingual('cit:title', 'authority',associated_resources) }}
+                      {{- bl.bilingual('cit:title', 'authority',associated_resources) -}}
                     </cit:CI_Citation>
                   </mcc:authority>
                   <mcc:code>
-                    <gco:CharacterString>{{ associated_resources['code'] }}</gco:CharacterString>
+                    <gco:CharacterString>{{- associated_resources['code'] -}}</gco:CharacterString>
                   </mcc:code>
                 </mcc:MD_Identifier>
               </cit:identifier>
 						</cit:CI_Citation>
 					</mri:name>
 					<mri:associationType>
-						<mri:DS_AssociationTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_AssociationTypeCode" codeListValue="{{ associated_resources['association_type'] }}"></mri:DS_AssociationTypeCode>
+						<mri:DS_AssociationTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_AssociationTypeCode" codeListValue="{{- associated_resources['association_type'] -}}"></mri:DS_AssociationTypeCode>
 					</mri:associationType>
 					<mri:initiativeType>
-						<mri:DS_InitiativeTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_InitiativeTypeCode" codeListValue="{{ associated_resources['initiative_type']  }}"></mri:DS_InitiativeTypeCode>
+						<mri:DS_InitiativeTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_InitiativeTypeCode" codeListValue="{{- associated_resources['initiative_type']  -}}"></mri:DS_InitiativeTypeCode>
 					</mri:initiativeType>
 				</mri:MD_AssociatedResource>
 			</mri:associatedResource>
       {% endfor %}
 
-      {{ bl.bilingual('mri:supplementalInformation', 'comment', record['metadata']) }}
+      {{- bl.bilingual('mri:supplementalInformation', 'comment', record['metadata']) -}}
     </mri:MD_DataIdentification>
   </mdb:identificationInfo>
 
@@ -630,7 +630,7 @@
       <mrd:distributor>
         <mrd:MD_Distributor>
           <mrd:distributorContact>
-        {{ contact.get_contact(c, 'distributor') }}
+        {{- contact.get_contact(c, 'distributor') -}}
             </mrd:distributorContact>
         </mrd:MD_Distributor>
       </mrd:distributor>
@@ -646,7 +646,7 @@
           <mrd:onLine>
             <cit:CI_OnlineResource>
               <cit:linkage>
-                <gco:CharacterString>{{ distribution['url']|e }}</gco:CharacterString>
+                <gco:CharacterString>{{- distribution['url']|e -}}</gco:CharacterString>
               </cit:linkage>
               <cit:protocol>
                 <gco:CharacterString>WWW:LINK</gco:CharacterString>
@@ -670,15 +670,15 @@
           <mrd:onLine>
             <cit:CI_OnlineResource>
               <cit:linkage>
-                <gco:CharacterString>{{ distribution.url|e }}</gco:CharacterString>
+                <gco:CharacterString>{{- distribution.url|e -}}</gco:CharacterString>
               </cit:linkage>
               <cit:protocol>
                 <gco:CharacterString>WWW:LINK</gco:CharacterString>
               </cit:protocol>
               <cit:name>
-                <gco:CharacterString>{{ distribution.name }}</gco:CharacterString>
+                <gco:CharacterString>{{- distribution.name -}}</gco:CharacterString>
               </cit:name>
-              {{ bl.bilingual('cit:description','description',distribution) }}
+              {{- bl.bilingual('cit:description','description',distribution) -}}
             </cit:CI_OnlineResource>
           </mrd:onLine>
         </mrd:MD_DigitalTransferOptions>
@@ -693,7 +693,7 @@
   {% if record['metadata']['history'] %}
   <mdb:resourceLineage>
     <mrl:LI_Lineage>
-      {{ bl.bilingual('mrl:statement', 'history', record['metadata']) }}
+      {{- bl.bilingual('mrl:statement', 'history', record['metadata']) -}}
         {# scope: CIOOS core mandatory #}
       <mrl:scope>
         <mcc:MD_Scope>
@@ -739,7 +739,7 @@
               <mcc:authority>
                 <cit:CI_Citation>
                   {# validation says cit:CI_Citation requires title #}
-                  {{ bl.bilingual('cit:title', 'name', record['platform']) }}
+                  {{- bl.bilingual('cit:title', 'name', record['platform']) -}}
                   {% if record['platform']['role'] and record['platform']['authority'] %}
                   {# citedResponsibleParty: mandatory #}
                   <cit:citedResponsibleParty>
@@ -754,7 +754,7 @@
                       <cit:party>
                         <cit:CI_Organisation>
                           {# name: mandatory #}
-                          {{ bl.bilingual('cit:name', 'authority', record['platform']) }}
+                          {{- bl.bilingual('cit:name', 'authority', record['platform']) -}}
                             {# CIOOS core mandatory element #}
                             {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/platform/MI_Platform/identifier/MD_Identifier/authority/CI_Citation/citedResponsibleParty/CI_Responsibility/party/CI_Party/name/CharacterString #}
                         </cit:CI_Organisation>
@@ -768,19 +768,19 @@
               <mcc:code>
                 {# CIOOS core mandatory element #}
                 {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/platform/MI_Platform/identifier/MD_Identifier/code/CharacterString #}
-                <gco:CharacterString>{{ record['platform']['id'] }}</gco:CharacterString>
+                <gco:CharacterString>{{- record['platform']['id'] -}}</gco:CharacterString>
               </mcc:code>
             </mcc:MD_Identifier>
           </mac:identifier>
           {# description: mandatory #}
             {# CIOOS core mandatory element #}
             {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/platform/MI_Platform/description/CharacterString #}
-          {{ bl.bilingual('mac:description', 'description', record['platform']) }}
+          {{- bl.bilingual('mac:description', 'description', record['platform']) -}}
 
           {% for instrument in record['platform']['instruments'] %}
             {# instrument: Recommended, if platform not used then this should be under mac:MI_AcquisitionInformation #}
 
-          {{ instr.get_instrument(instrument) }}
+          {{- instr.get_instrument(instrument) -}}
 
           {% endfor %}
         </mac:MI_Platform>
@@ -804,7 +804,7 @@
       </mac:scope>
 
       {% for instrument in record['instruments'] %}
-          {{ instr.get_instrument(instrument) }}
+          {{- instr.get_instrument(instrument) -}}
       {% endfor %}
 
       </mac:MI_AcquisitionInformation>

--- a/metadata_xml/template_functions.py
+++ b/metadata_xml/template_functions.py
@@ -7,14 +7,11 @@ Defines custom functions used by the Jinja template
 Also defines metadata_to_xml()
 
 """
-
-import pathlib
-import xml.dom.minidom
-
-from datetime import date
 import os
-
+import pathlib
+from datetime import date
 from jinja2 import Environment, FileSystemLoader
+from yattag import indent
 
 SCHEMA_FOLDER_NAME = "iso19115-cioos-template"
 
@@ -91,7 +88,6 @@ def metadata_to_xml(record):
     template = template_env.get_template("main.j2")
 
     xml_string = template.render({"record": record})
-    dom = xml.dom.minidom.parseString(xml_string)
+    pretty_string = indent(xml_string)
 
-    pretty_xml_as_string = dom.toprettyxml(newl="").replace("\n\n", "\n")
-    return pretty_xml_as_string
+    return pretty_string

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(name='metadata_xml',
 
       install_requires=['Jinja2 == 2.10.3',
                         'PyYAML == 5.1.2',
+                        'yattag == 1.14.0'
                         ]
 
       )


### PR DESCRIPTION
Fixes newlines issue and beautifies XML as well. I tried many XML formatters and the `yattag` package is the only one that worked..

Also switches most `{{` to  `{{-` so that all fields are trimmed

Fixes #93