### PR TITLE
allow for french text in license title, if available

### DIFF
--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -550,9 +550,7 @@
         <mco:MD_LegalConstraints>
           <mco:reference>
             <cit:CI_Citation>
-              <cit:title>
-                <gco:CharacterString>{{ licence['title'] }}</gco:CharacterString>
-              </cit:title>
+                {{ bl.bilingual('cit:title', 'title', licence) }}
               <cit:identifier>
                 <mcc:MD_Identifier>
                   <mcc:code>


### PR DESCRIPTION
This is to fix a bug that occurs when using a license that has french text