### PR TITLE
fix validation, see https://github.com/ISO-TC211/XML/issues/210

### DIFF
--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -17,7 +17,7 @@
 {% import 'instrument.j2' as instr with context %}
 
 <mdb:MD_Metadata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://standards.iso.org/iso/19115/-3/mdb/2.0 https://standards.iso.org/iso/19115/-3/mds/2.0/mds.xsd"
+  xsi:schemaLocation="http://standards.iso.org/iso/19115/-3/mdb/2.0 https://schemas.isotc211.org/19115/-3/mdb/2.0/mdb.xsd"
   xmlns:gml="http://www.opengis.net/gml/3.2"
   xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0"
   xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"

--- a/validate.sh
+++ b/validate.sh
@@ -3,5 +3,4 @@
 # use like `sh validate.sh record.xml`
 SCRIPT_DIR=$(dirname $(realpath "$0"))
 SCHEMA_FOLDER="$SCRIPT_DIR/cioos-schema/schema"
-export XML_CATALOG_FILES=$SCRIPT_DIR/cioos-schema/catalog.xsd
-xmllint --noout --schema "$SCHEMA_FOLDER"/standards.iso.org/iso/19115/-3/mds/2.0/mds.xsd "$1" --nowarning
+xmllint --noout --schema "$SCHEMA_FOLDER"/schemas.isotc211.org/19115/-3/mdb/2.0/mdb.xsd "$1" --nowarning


### PR DESCRIPTION
Replacing deprecated http://standards.iso.org/ with https://schemas.isotc211.org/ as root XSD. This makes XML validation much simpler as there is a broken link in the http://standards.iso.org schema that led a workaround that is no longer needed. 

Now XML files can be validated using [Oxygen XML Editor](https://www.oxygenxml.com/) without pre-configuring anything. This makes https://github.com/cioos-siooc/cioos-oxygen-iso19115-howto irrelevant so I will remove this repo.

See https://github.com/ISO-TC211/XML/issues/210

@ItaloBorrelli