### PR TITLE
add platform type

### DIFF
--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -760,6 +760,21 @@
           {{- instr.get_instrument(instrument) -}}
 
           {% endfor %}
+
+          {% if record['platform']['type'] %}
+          
+          {# cant have 'otherProperty' without 'instrument'. This adds dummy instrument #}
+          {% if instrument not in record['platform']['instruments']%}
+          <mac:instrument/> 
+          {% endif %}
+
+          <mac:otherProperty xlink:href="http://vocab.nerc.ac.uk/collection/L06/current/" xlink:title="SeaVoX Platform Categories">
+            <gco:Record>
+                <gco:CharacterString>{{- record['platform']['type'] -}}</gco:CharacterString>
+            </gco:Record>
+          </mac:otherProperty>
+          {% endif %}
+
         </mac:MI_Platform>
       </mac:platform>
     </mac:MI_AcquisitionInformation>

--- a/sample_records/record.yml
+++ b/sample_records/record.yml
@@ -112,6 +112,7 @@ distribution:
       fr: pdf description in French
 
 platform:
+  type: drifting subsurface profiling float
   name: platform_name
   authority: platform_authority
   id: platform id


### PR DESCRIPTION
Adds platform type, to be populated with a Seavox Platform Category (NERC L06, see http://vocab.nerc.ac.uk/collection/L06/current/)