### PR TITLE
separate citation contacts

### DIFF
--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -107,13 +107,13 @@
   </mdb:metadataScope>
   {# contact: mandatory #}
   {% for c in record['contact'] %}
-      {% for role in c.roles %}
-        {% if role in ['custodian','pointOfContact']%}
+        {% if not c.inCitation %}
+        {% for role in c.roles %}
       <mdb:contact>
               {{- contact.get_contact(c, role) -}}
       </mdb:contact>
+        {% endfor %}
         {% endif %}
-      {% endfor %}
   {% endfor %}
 
   {# schema requires at least one mdb:dateInfo field #}
@@ -262,13 +262,13 @@
           {% endif %}
 
           {% for c in record['contact'] %}
+          {% if c.inCitation %}
           {% for role in c['roles'] %}
-          {% if role not in ['custodian','pointOfContact','distributor'] %}
-          <cit:citedResponsibleParty>
-            {{- contact.get_contact(c, role) -}}
-          </cit:citedResponsibleParty>
-          {% endif %}
+            <cit:citedResponsibleParty>
+              {{- contact.get_contact(c, role) -}}
+            </cit:citedResponsibleParty>
           {% endfor %}
+          {% endif %}
           {% endfor %}
 
 

--- a/sample_records/record.yml
+++ b/sample_records/record.yml
@@ -86,6 +86,8 @@ contact:
       name: Shiela Jones
       position: Scientist
       email: foo@bar.ca
+    inCitation: true
+
   - roles:
       - author
     individual:
@@ -93,7 +95,7 @@ contact:
       position: Scientist
       email: foo2@bar.ca
       country: Canada
-
+    inCitation: true
   - roles:
       - distributor
     organization:


### PR DESCRIPTION
With this PR, a contact will only appear under `citedResponsibleParty` if it has been flagged with `inCitation` in the YAML.

This shift allows for an 'Appear in citation' checkbox in the metadata form, making it no longer dependant on what roles the contact has.