### PR TITLE
mdb:contact set to contacts with custodian role

### DIFF
--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -107,7 +107,7 @@
   </mdb:metadataScope>
   {# contact: mandatory #}
   {% for c in record['contact'] %}
-        {% if not c.inCitation %}
+        {% if not c.inCitation or "custodian" in c.roles %}
         {% for role in c.roles %}
       <mdb:contact>
               {{- contact.get_contact(c, role) -}}


### PR DESCRIPTION
When all contacts in a record are checked "Appear in citation", the XML record ends up with no `mdb:contact` section, which breaks schema validation. Since every record has a role with `custodian`, this PR sets `mdb:contact` to each contact with `custodian` role set