### PR TITLE
233 auto translation flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__
 *.egg-info
 
 venv/
+env/
 .vscode
 .mypy*
 notforrepo

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To convert a Yaml file to XML, run:
 
 eg:
 
-`python -m metadata_xml -f sample_records/record.yaml`
+`python -m metadata_xml -f sample_records/record.yml`
 
 ## Importing into other Python projects
 

--- a/metadata_xml/iso19115-cioos-template/bilingual.j2
+++ b/metadata_xml/iso19115-cioos-template/bilingual.j2
@@ -1,4 +1,4 @@
-{% macro bilingual(element,key,record_section) -%}
+{% macro bilingual(element,key,record_section, translationKey) -%}
 {% set value = record_section[key] %}
 
 {% if (value is not mapping) or (value.items()|length==1 and lang in value)  %}
@@ -19,7 +19,11 @@
           <lan:PT_FreeText>
           {% for secondary_lang,val in value.items() %}
           {% if secondary_lang != lang %}
+          {% if translationKey %}
+            <lan:textGroup xlink:href="https://cioos.ca/translation_method" xlink:role="translation" xlink:title="{{record_section[translationKey]}}">
+          {% else %}
             <lan:textGroup>
+          {% endif %}
               <lan:LocalisedCharacterString locale="#{{secondary_lang}}">{{- val|e -}}</lan:LocalisedCharacterString>
             </lan:textGroup>
           {% endif %}

--- a/metadata_xml/iso19115-cioos-template/bilingual.j2
+++ b/metadata_xml/iso19115-cioos-template/bilingual.j2
@@ -1,4 +1,4 @@
-{% macro bilingual(element,key,record_section, translationKey) -%}
+{% macro bilingual(element,key,record_section) -%}
 {% set value = record_section[key] %}
 
 {% if (value is not mapping) or (value.items()|length==1 and lang in value)  %}
@@ -17,10 +17,12 @@
         <gco:CharacterString>{{- value[lang]|e -}}</gco:CharacterString>
     {% endif %}
           <lan:PT_FreeText>
+          {% set translations = value.get("translations", {})%}
           {% for secondary_lang,val in value.items() %}
-          {% if secondary_lang != lang %}
-          {% if translationKey %}
-            <lan:textGroup xlink:href="https://cioos.ca/translation_method" xlink:role="translation" xlink:title="{{record_section[translationKey]}}">
+          {% if secondary_lang != lang and secondary_lang != 'translations'%}
+          {% set translationMessage = translations.get(secondary_lang,{}).get("message")%}
+          {% if translationMessage %}
+            <lan:textGroup xlink:href="https://cioos.ca/translation_method" xlink:role="translation" xlink:title="{{translationMessage}}">
           {% else %}
             <lan:textGroup>
           {% endif %}

--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -228,7 +228,7 @@
       <mri:citation>
         <cit:CI_Citation>
           {# title: mandatory #}
-          {{- bl.bilingual('cit:title','title', record['identification'], 'titleTranslationMethod') -}}
+          {{- bl.bilingual('cit:title','title', record['identification']) -}}
 
           {# date pubished/revised isnt required #}
           {% if 'dates' in record['identification'] %}
@@ -283,7 +283,7 @@
       {# abstract: mandatory #}
         {# CIOOS core mandatory element #}
         {# MI_Metadata/identificationInfo/MD_DataIdentification/abstract/CharacterString #}
-      {{- bl.bilingual('mri:abstract', 'abstract', record['identification'], 'abstractTranslationMethod') -}}
+      {{- bl.bilingual('mri:abstract', 'abstract', record['identification']) -}}
       {{- bl.bilingual('mri:credit', 'acknowledgement', record['identification']) -}}
       <mri:status>
         <mcc:MD_ProgressCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ProgressCode" codeListValue="{{- record['identification']['progress_code'] or 'onGoing' -}}">
@@ -586,7 +586,7 @@
         {# MD_Constraints: CIOOS core mandatory #}
         <mco:MD_Constraints>
           {# useLimitation: CIOOS core mandatory #}
-           {{- bl.bilingual('mco:useLimitation', 'limitations', record['metadata']['use_constraints'], 'limitationsTranslationMethod') -}}
+           {{- bl.bilingual('mco:useLimitation', 'limitations', record['metadata']['use_constraints']) -}}
         </mco:MD_Constraints>
       </mri:resourceConstraints>
       {% endif %}
@@ -757,7 +757,7 @@
           {# description: mandatory #}
             {# CIOOS core mandatory element #}
             {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/platform/MI_Platform/description/CharacterString #}
-          {{- bl.bilingual('mac:description', 'description', record['platform'], 'platformDescriptionTranslationMethod') -}}
+          {{- bl.bilingual('mac:description', 'description', record['platform']) -}}
 
           {% for instrument in record['platform']['instruments'] %}
             {# instrument: Recommended, if platform not used then this should be under mac:MI_AcquisitionInformation #}

--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -228,7 +228,7 @@
       <mri:citation>
         <cit:CI_Citation>
           {# title: mandatory #}
-          {{- bl.bilingual('cit:title','title', record['identification']) -}}
+          {{- bl.bilingual('cit:title','title', record['identification'], 'titleTranslationMethod') -}}
 
           {# date pubished/revised isnt required #}
           {% if 'dates' in record['identification'] %}
@@ -283,7 +283,7 @@
       {# abstract: mandatory #}
         {# CIOOS core mandatory element #}
         {# MI_Metadata/identificationInfo/MD_DataIdentification/abstract/CharacterString #}
-      {{- bl.bilingual('mri:abstract', 'abstract', record['identification']) -}}
+      {{- bl.bilingual('mri:abstract', 'abstract', record['identification'], 'abstractTranslationMethod') -}}
       {{- bl.bilingual('mri:credit', 'acknowledgement', record['identification']) -}}
       <mri:status>
         <mcc:MD_ProgressCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ProgressCode" codeListValue="{{- record['identification']['progress_code'] or 'onGoing' -}}">
@@ -586,7 +586,7 @@
         {# MD_Constraints: CIOOS core mandatory #}
         <mco:MD_Constraints>
           {# useLimitation: CIOOS core mandatory #}
-           {{- bl.bilingual('mco:useLimitation', 'limitations', record['metadata']['use_constraints']) -}}
+           {{- bl.bilingual('mco:useLimitation', 'limitations', record['metadata']['use_constraints'], 'limitationsTranslationMethod') -}}
         </mco:MD_Constraints>
       </mri:resourceConstraints>
       {% endif %}
@@ -757,7 +757,7 @@
           {# description: mandatory #}
             {# CIOOS core mandatory element #}
             {# MI_Metadata/acquisitionInformation/MI_AcquisitionInformation/platform/MI_Platform/description/CharacterString #}
-          {{- bl.bilingual('mac:description', 'description', record['platform']) -}}
+          {{- bl.bilingual('mac:description', 'description', record['platform'], 'platformDescriptionTranslationMethod') -}}
 
           {% for instrument in record['platform']['instruments'] %}
             {# instrument: Recommended, if platform not used then this should be under mac:MI_AcquisitionInformation #}

--- a/sample_records/record.yml
+++ b/sample_records/record.yml
@@ -13,7 +13,10 @@ metadata:
   language: en
   maintenance_note: maintenance_note
   use_constraints:
-    limitations: limitations
+    limitations:
+      en: limitations in english
+      fr: limitations in french
+    limitationsTranslationMethod: Auto-translated using AWS
     licence:
       title: Creative Commons Attribution 4.0
       code: CC-BY-4.0
@@ -38,11 +41,13 @@ identification:
   title:
     en: title in english
     fr: title in french
+  titleTranslationMethod: Auto-translated using AWS
   identifier: http://dx.doi.org/10.1093/ajae/aaq063
 
   abstract:
     en: abstract in english
     fr: abstract in french
+  abstractTranslationMethod: Auto-translated using AWS
   associated_resources:
     - title:
         en: associated resource title in english
@@ -123,7 +128,10 @@ platform:
   name: platform_name
   authority: platform_authority
   id: platform id
-  description: platform_description
+  description:
+    en: platformDescription in English
+    fr: platformDescription in French
+  platformDescriptionTranslationMethod: Auto-translated using AWS
   instruments:
     - id: 123
       manufacturer: manufacturer en 1

--- a/sample_records/record.yml
+++ b/sample_records/record.yml
@@ -16,7 +16,10 @@ metadata:
     limitations:
       en: limitations in english
       fr: limitations in french
-    limitationsTranslationMethod: Auto-translated using AWS
+      translations:
+        fr: 
+          validated: false
+          message: Auto-translated using AWS
     licence:
       title: Creative Commons Attribution 4.0
       code: CC-BY-4.0
@@ -41,13 +44,19 @@ identification:
   title:
     en: title in english
     fr: title in french
-  titleTranslationMethod: Auto-translated using AWS
+    translations:
+      fr: 
+        validated: false
+        message: Auto-translated using AWS
   identifier: http://dx.doi.org/10.1093/ajae/aaq063
 
   abstract:
     en: abstract in english
     fr: abstract in french
-  abstractTranslationMethod: Auto-translated using AWS
+    translations:
+        fr: 
+          validated: false
+          message: Auto-translated using AWS
   associated_resources:
     - title:
         en: associated resource title in english
@@ -131,7 +140,10 @@ platform:
   description:
     en: platformDescription in English
     fr: platformDescription in French
-  platformDescriptionTranslationMethod: Auto-translated using AWS
+    translations:
+        fr: 
+          validated: true
+          message: Auto-translated using AWS
   instruments:
     - id: 123
       manufacturer: manufacturer en 1


### PR DESCRIPTION

The changes described in this PR are related the changes included in https://github.com/cioos-siooc/metadata-entry-form/pull/302

This PR contributes to solving the problem outlined in https://github.com/cioos-siooc/metadata-entry-form/issues/233

The key features and fixes introduced are summarized as follows:

* fixed a small typo in the `yml` file extension in the sample command listed in the README
* added `env/` to the `.gitignore`
* updated the sample `record.yml` file to include the auto-translation message for title, abstract, limitations, and platform description.
* in the `main.j2` jinja template, added the variables storing auto-translation method message for title, abstract, limitations, and platform description
* updated `bilingual.j2` jinja template to look for and include the translation method message as `translationKey`