### PR TITLE
Enhance bilingual macros and add YAML download script

### DIFF
--- a/download_cioos_waf.sh
+++ b/download_cioos_waf.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Download all metadata files from the CIOOS WAF into a local folder.
+# Usage:
+#   ./download_unpublished.sh [WAF_URL] [DEST_DIR]
+# Defaults:
+#   WAF_URL  = https://waf.forms.cioos.ca/metadata/unpublished/
+#   DEST_DIR = metadata
+
+set -euo pipefail
+
+WAF_URL="${1:-https://waf.forms.cioos.ca/metadata/}"
+DEST_DIR="${2:-metadata}"
+
+if ! command -v wget >/dev/null 2>&1; then
+  echo "Error: wget is required. Install it (e.g., sudo apt-get install wget) and retry." >&2
+  exit 1
+fi
+
+mkdir -p "${DEST_DIR}"
+
+# Recursively fetch YAML/YML files only, do not ascend to parent, and avoid index pages.
+# -nH drops the host directory; --cut-dirs=1 strips the leading 'metadata' segment so
+# files land under DEST_DIR/unpublished/...
+wget \
+  --recursive \
+  --no-parent \
+  --no-host-directories \
+  --cut-dirs=1 \
+  --accept '*.yaml,*.yml' \
+  --reject 'index.html*' \
+  --timestamping \
+  --directory-prefix="${DEST_DIR}" \
+  "${WAF_URL}"
+
+echo "Downloaded files under: ${DEST_DIR}"

--- a/metadata_xml/iso19115-cioos-template/bilingual.j2
+++ b/metadata_xml/iso19115-cioos-template/bilingual.j2
@@ -16,10 +16,20 @@
       {% if value[lang]|trim != "None" %}
         <gco:CharacterString>{{- value[lang]|e -}}</gco:CharacterString>
     {% endif %}
+        {# Only include PT_FreeText if at least one non-empty secondary translation exists #}
+        {% set translations = value.get("translations", {})%}
+        {% set ns = namespace(has_secondary=false) %}
+        {% for secondary_lang,val in value.items() %}
+        {% if secondary_lang != lang and secondary_lang != 'translations' and (val|string)|trim and (val|string)|trim !=
+        'None' %}
+        {% set ns.has_secondary = true %}
+        {% endif %}
+        {% endfor %}
+
+        {% if ns.has_secondary %}
           <lan:PT_FreeText>
-          {% set translations = value.get("translations", {})%}
-          {% for secondary_lang,val in value.items() %}
-          {% if secondary_lang != lang and secondary_lang != 'translations'%}
+          {% for secondary_lang,val in value.items()%}
+          {% if secondary_lang != lang and secondary_lang != 'translations' and (val|string)|trim and (val|string)|trim != 'None' %}
           {% set translationMessage = translations.get(secondary_lang,{}).get("message")%}
           {% if translationMessage %}
             <lan:textGroup xlink:href="https://cioos.ca/translation_method" xlink:role="translation" xlink:title="{{translationMessage}}">
@@ -31,6 +41,7 @@
           {% endif %}
           {% endfor %}
           </lan:PT_FreeText>
+      {% endif %}
       </{{ element }}>
 {% endif %}
 {% endmacro %}

--- a/metadata_xml/iso19115-cioos-template/charstring.j2
+++ b/metadata_xml/iso19115-cioos-template/charstring.j2
@@ -2,22 +2,23 @@
    but you can specify the element's namespace, and alternate language code
 #}
 {% macro get_freetext(element, language_alternate, myvars) -%}
-{% if language_alternate is none or myvars[1] is none %}
-      {% if myvars[0]|trim != "None" %}
-      <{{ element }}>
-        <gco:CharacterString>{{ myvars[0]|trim|e }}</gco:CharacterString>
-      </{{ element }}>
-      {% endif %}
-{% else %}
-      {% if myvars[0]|trim != "None" %}
+{% set primary = (myvars[0] | default('')) %}
+{% set alt = (myvars[1] | default('')) %}
+{% set has_primary = (primary|string)|trim and (primary|string)|trim != 'None' %}
+{% set has_alt = (language_alternate is not none) and (alt is not none) and (alt|string)|trim and (alt|string)|trim != 'None' %}
+
+{% if has_alt and has_primary %}
       <{{ element }} xsi:type="lan:PT_FreeText_PropertyType">
-        <gco:CharacterString>{{ myvars[0]|trim|e }}</gco:CharacterString>
+        <gco:CharacterString>{{ primary|trim|e }}</gco:CharacterString>
           <lan:PT_FreeText>
             <lan:textGroup>
-              <lan:LocalisedCharacterString locale="#{{language_alternate}}">{{ myvars[1]|trim|e }}</lan:LocalisedCharacterString>
+              <lan:LocalisedCharacterString locale="#{{language_alternate}}">{{ alt|trim|e }}</lan:LocalisedCharacterString>
             </lan:textGroup>
           </lan:PT_FreeText>
       </{{ element }}>
-    {% endif %}
+{% elif has_primary %}
+    <{{ element }}>
+      <gco:CharacterString>{{ primary|trim|e }}</gco:CharacterString>
+    </{{ element }}>
 {% endif %}
 {% endmacro %}


### PR DESCRIPTION
Improve bilingual macros to conditionally include secondary translations and enhance handling of free text elements. Introduce a script for downloading YAML files locally from the specified WAF URL.