### PR TITLE
temporal_begin/end fixes

### DIFF
--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -491,7 +491,7 @@
                   <gml:beginPosition indeterminatePosition="unknown" />
                   {% endif %}
 
-                  {% if record['identification']['temporal_end'] %}
+                  {% if record['identification']['temporal_end'] and not record['identification']['temporal_end'] == 'now' %}
                   <gml:endPosition>{{- record['identification']['temporal_end']|normalize_datestring -}}</gml:endPosition>
                   {% elif not record['identification']['progress_code'] or record['identification']['progress_code'] == 'onGoing' %}
                   <gml:endPosition indeterminatePosition="now" />

--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -491,7 +491,7 @@
                   <gml:beginPosition indeterminatePosition="unknown" />
                   {% endif %}
 
-                  {% if record['identification']['temporal_end'] and not record['identification']['temporal_end'] == 'now' %}
+                  {% if record['identification']['temporal_end'] and not record['identification']['progress_code'] == 'onGoing'%}
                   <gml:endPosition>{{- record['identification']['temporal_end']|normalize_datestring -}}</gml:endPosition>
                   {% elif not record['identification']['progress_code'] or record['identification']['progress_code'] == 'onGoing' %}
                   <gml:endPosition indeterminatePosition="now" />

--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -491,7 +491,7 @@
                   <gml:beginPosition indeterminatePosition="unknown" />
                   {% endif %}
 
-                  {% if record['identification']['temporal_end'] and not record['identification']['progress_code'] == 'onGoing'%}
+                  {% if record['identification']['temporal_end'] and not record['identification']['progress_code'] == 'onGoing' %}
                   <gml:endPosition>{{- record['identification']['temporal_end']|normalize_datestring -}}</gml:endPosition>
                   {% elif not record['identification']['progress_code'] or record['identification']['progress_code'] == 'onGoing' %}
                   <gml:endPosition indeterminatePosition="now" />

--- a/metadata_xml/iso19115-cioos-template/main.j2
+++ b/metadata_xml/iso19115-cioos-template/main.j2
@@ -486,13 +486,13 @@
               <gex:extent>
                 <gml:TimePeriod gml:id="time_period">
                   {% if record['identification']['temporal_begin'] %}
-                  <gml:beginPosition>{{- record['identification']['temporal_begin'] -}}</gml:beginPosition>
+                  <gml:beginPosition>{{- record['identification']['temporal_begin']|normalize_datestring -}}</gml:beginPosition>
                   {% else %}
                   <gml:beginPosition indeterminatePosition="unknown" />
                   {% endif %}
 
                   {% if record['identification']['temporal_end'] %}
-                  <gml:endPosition>{{- record['identification']['temporal_end'] -}}</gml:endPosition>
+                  <gml:endPosition>{{- record['identification']['temporal_end']|normalize_datestring -}}</gml:endPosition>
                   {% elif not record['identification']['progress_code'] or record['identification']['progress_code'] == 'onGoing' %}
                   <gml:endPosition indeterminatePosition="now" />
                   {% else %}


### PR DESCRIPTION
Hello, recently I ran into some difficulties converting a yml to to an xml. It got me digging into the jinja templates to debug what was going on. I thought I'd share how I ran into these issues and what I did to fix them. I tested these changes with pytest and `test_all_records.sh`. let me know what you think! 

* temporal_begin and temporal_end format
   * My yml wasn't using strings for any date/time fields. They were in the correct format in the yml, just not within quotes. So python would convert it to a datetime object when parsing the yml. This was fine for the identification date fields because it was going through the normalize_datestring function. However, the temporal_begin/end would render the datetime in the default string export format, which wasn't correct.
   * I changed it so both fields now also go through the normalize_datestring function.

* temporal_end being more flexible
   * When I was looking at how to make my dataset classified as "onGoing" I saw both "now" and "onGoing" keywords being used. I assumed the yml still wanted a temporal_end so I set `temporal_end: now` which creates an incorrect xml line assuming 'now' is the date. This is happening because the template checks if anything exists in temporal_end before checking the `progress_code` line.
   * I changed it so the first conditional also checks to see if the status_code isn't onGoing.